### PR TITLE
Disabled everyone and here mentions

### DIFF
--- a/controllers/discord.js
+++ b/controllers/discord.js
@@ -19,7 +19,7 @@ module.exports = class Discord extends require("./template.js") {
 			});
 		}
 
-		this.client = new (require("discord.js")).Client({disableMentions: "everyone"});
+		this.client = new (require("discord.js")).Client({ disableMentions: "everyone" });
 
 		this.initListeners();
 

--- a/controllers/discord.js
+++ b/controllers/discord.js
@@ -19,7 +19,7 @@ module.exports = class Discord extends require("./template.js") {
 			});
 		}
 
-		this.client = new (require("discord.js")).Client();
+		this.client = new (require("discord.js")).Client({disableMentions: "everyone"});
 
 		this.initListeners();
 


### PR DESCRIPTION
Earlier today at smaczny's Discord, someone used randomline and pinged everyone.
https://cdn.zneix.eu/eA4ZYna.jpeg
![if you read this i von ZULUL](https://cdn.zneix.eu/eA4ZYna.jpeg)

To prevent random unwanted situations like this, Discord recently introduced an option to control which mentions will go through and `discord.js` has an according property in `ClientOptions`.
By the way, this `ClientOption` works in a way, so it only sets default `MessageOption` for every message posted to Discord, meaning if you ever need to ping everyone / here with the bot, you can just set different `MessageOption` without touching anything else.

Reference:  
[Discord API Documentation](https://discord.com/developers/docs/resources/channel#allowed-mentions-object-allowed-mention-types)
[discord.js Documentation](https://discord.js.org/#/docs/main/stable/typedef/ClientOptions) (Ctrl + F disableMentions)