### PR TITLE
Add custom mariadb port support

### DIFF
--- a/db-access.js.example
+++ b/db-access.js.example
@@ -11,6 +11,7 @@
 	process.env.MARIA_PASSWORD = "your_password"; // Database password
 	
 	process.env.MARIA_HOST = "your_host"; // If using hosts, fill this and remove socket
+	process.env.MARIA_PORT = "your_port"; // If using hosts with custom port, otherwise port 3306 is used
 	process.env.MARIA_SOCKET_PATH = "your_socket"; // If using sockets, fill this and remove host
 	
 	process.env.MARIA_CONNECTION_LIMIT = 100; // Explicit database connection limit

--- a/init/setup.js
+++ b/init/setup.js
@@ -24,6 +24,7 @@
 		["username", "MARIA_USER", "your_username"],
 		["password", "MARIA_PASSWORD", "your_password"],
 		["host", "MARIA_HOST", "your_host"],
+		["port", "MARIA_PORT", "your_port"],
 		["socket", "MARIA_SOCKET_PATH", "your_socket"],
 	];
 
@@ -53,7 +54,7 @@
 			console.log(`Database ${name} is already set up - skipping...`);
 		}
 		else {
-			const result = await ask(`Set up database ${name} - type a new value (or nothing to keep empty)\n`);
+			const result = await ask(`Set up database ${name} - type a new value (or nothing to ${name === 'port' ? 'use 3306' : 'keep empty'})\n`);
 			
 			if (!result) {
 				accessFileString = accessFileString.replace(implicit, "");


### PR DESCRIPTION
Adds ability to set up a custom port for supibot's database. See supinic/supi-core#10 for where this variable would be used.