### PR TITLE
ChatGPT 3.5 in `$gpt`

### DIFF
--- a/commands/check/subcommands.js
+++ b/commands/check/subcommands.js
@@ -277,49 +277,6 @@ module.exports = (command) => [
 		}
 	},
 	{
-		name: "chatgpt-history",
-		aliases: ["chat-gpt-history", "gpt-history"],
-		description: "Exports your currently active ChatGPT history to Pastebin, if you have any.",
-		execute: async (context) => {
-			let GptHistory;
-			try {
-				GptHistory = require("../gpt/history-control.js");
-			}
-			catch {
-				return {
-					success: false,
-					reply: `The GPT history module is currently not available!`
-				};
-			}
-
-			const history = await GptHistory.dump(context.user);
-			if (history.length === 0) {
-				return {
-					reply: `You have no ChatGPT history at the moment.`
-				};
-			}
-
-			const string = history.join("\n\n");
-			const { body } = await sb.Pastebin.post(string, {
-				name: `ChatGPT history for ${context.user.Name}`,
-				privacy: "unlisted",
-				expiration: "1D"
-			});
-
-			if (!body) {
-				return {
-					success: false,
-					reply: `Could not export the ChatGPT history! Please try again later.`
-				};
-			}
-			else {
-				return {
-					reply: body
-				};
-			}
-		}
-	},
-	{
 		name: "cookie",
 		aliases: [],
 		description: "Checks if someone (or you, if not provided) has their fortune cookie available for today.",
@@ -617,7 +574,6 @@ module.exports = (command) => [
 				? ["Your reminder", `to ${reminderUser.Name}`]
 				: ["Reminder", `by ${reminderUser.Name} to you`];
 
-			/** @type {CustomDate|null} */
 			const schedule = reminder.Schedule;
 			const delta = (reminder.Schedule)
 				? ` (${sb.Utils.timeDelta(schedule)})`

--- a/commands/gpt/config.json
+++ b/commands/gpt/config.json
@@ -1,75 +1,36 @@
 {
-  "defaultPromptPefix": "You are a chat bot. Don't use slurs.",
   "defaultTemperature": 0.5,
+  "defaultHistoryMode": "enabled",
   "globalInputLimit": 5000,
   "outputLimit": {
     "default": 50,
     "maximum": 100
   },
-  "queryNames": {
-    "prompt": "Query",
-    "response": "Answer"
-  },
   "lengthLimitExceededMessage": {
-    "history": "Maximum history length exceeded for this model! Shorten your query, use a lower-ranked model, or wipe your history with \"$unset gpt-history\" instead.",
-    "regular": "Maximum query length exceeded for this model! Shorten your query, or use a lower-ranked model instead."
+    "history": "Maximum history length exceeded for this model! Shorten your query, or wipe your history with \"$unset gpt-history\" instead.",
+    "regular": "Maximum query length exceeded for this model! Shorten your query instead."
   },
   "userTokenLimits": {
     "regular": {
-      "hourly": 100,
+      "hourly": 200,
       "daily": 1000
     },
     "subscriber": {
-      "hourly": 1000,
+      "hourly": 2000,
       "daily": 10000
     }
   },
   "models": {
-    "ada": {
-      "url": "text-ada-001",
-      "default": false,
-      "inputLimit": 5000,
-      "outputLimit": {
-        "default": 500,
-        "maximum": 2500
-      },
-      "usageDivisor": 50,
-      "usePromptPrefix": false
-    },
-    "babbage": {
-      "url": "text-babbage-001",
-      "default": false,
-      "inputLimit": 5000,
-      "outputLimit": {
-        "default": 400,
-        "maximum": 2000
-      },
-      "usageDivisor": 40,
-      "usePromptPrefix": false
-    },
-    "curie": {
-      "url": "text-curie-001",
+    "turbo": {
+      "url": "gpt-3.5-turbo",
+      "chat": true,
       "default": true,
-      "disabled": false,
-      "disableReason": "unsafe generated content",
       "inputLimit": 2500,
       "outputLimit": {
         "default": 100,
         "maximum": 500
       },
-      "usageDivisor": 10,
-      "usePromptPrefix": false
-    },
-    "davinci": {
-      "url": "text-davinci-003",
-      "default": false,
-      "inputLimit": 250,
-      "outputLimit": {
-        "default": 50,
-        "maximum": 250
-      },
-      "usageDivisor": 1,
-      "usePromptPrefix": false
+      "usageDivisor": 10
     }
   }
 }

--- a/commands/gpt/moderation.js
+++ b/commands/gpt/moderation.js
@@ -1,0 +1,53 @@
+const check = async (context, text) => {
+	text = text.trim();
+
+	const moderationCheck = await sb.Got("GenericAPI", {
+		method: "POST",
+		throwHttpErrors: false,
+		url: `https://api.openai.com/v1/moderations`,
+		headers: {
+			Authorization: `Bearer ${sb.Config.get("API_OPENAI_KEY")}`
+		},
+		json: {
+			input: text
+		}
+	});
+
+	if (!moderationCheck.ok || !Array.isArray(moderationCheck.body.results)) {
+		const logId = await sb.Logger.log(
+			"Command.Warning",
+			`GPT moderation failed! ${JSON.stringify({ body: moderationCheck.body })}`,
+			context.channel,
+			context.user
+		);
+
+		return {
+			success: false,
+			reply: `Could not check your response for moderation! Please try again later. Reference ID: ${logId}`
+		};
+	}
+
+	const [moderationResult] = moderationCheck.body.results;
+	const { categories, category_scores: scores } = moderationResult;
+	if (categories.hate || categories["violence/graphic"] || categories["sexual/minors"]) {
+		const logId = await sb.Logger.log(
+			"Command.Warning",
+			`Unsafe GPT content generated! ${JSON.stringify({ text, scores })}`,
+			context.channel,
+			context.user
+		);
+
+		return {
+			success: false,
+			reply: `Unsafe content generated! Reference ID: ${logId}`
+		};
+	}
+
+	return {
+		success: true
+	};
+};
+
+module.exports = {
+	check
+};

--- a/commands/set/index.js
+++ b/commands/set/index.js
@@ -520,41 +520,6 @@ module.exports = {
 					}
 				},
 				{
-					name: "gpt-history",
-					aliases: ["gpthistory"],
-					parameter: "arguments",
-					description: "Deletes your current ChatGPT history.",
-					pipe: true,
-					set: () => ({
-						reply: `Use the "$gpt history:true" command to set your history with some prompts.`
-					}),
-					unset: async (context) => {
-						let GptHistory;
-						try {
-							GptHistory = require("../gpt/history-control.js");
-						}
-						catch {
-							return {
-								success: false,
-								reply: `The GPT history module is currently not available!`
-							};
-						}
-
-						const existing = await GptHistory.get(context.user);
-						if (existing.length === 0) {
-							return {
-								success: false,
-								reply: `You have no ChatGPT history saved at the moment!`
-							};
-						}
-
-						await GptHistory.reset(context.user);
-						return {
-							reply: `Your ChatGPT history has been successfuly deleted.`
-						};
-					}
-				},
-				{
 					name: "birthday",
 					aliases: ["bday"],
 					parameter: "arguments",


### PR DESCRIPTION
- old functionality is removed, Ada, Babbage, Curie and Davinci models are not available
- only conversational model available at the moment is "Turbo"
- history is now kept by default, `$gpt history:disable` and `$gpt history:enable` can change this default behaviour for each user
- moved history manipulation from `$unset` and `$check` to `$gpt history:clear` and `$gpt history:check` respectively
- increased hourly limits 2x (100 → 200 and 1000 → 2000 for regulars and subs, respectively)
- refactored moderation into its own module