### PR TITLE
Add missing got instances (S#13406)

### DIFF
--- a/commands/9gag/index.js
+++ b/commands/9gag/index.js
@@ -20,20 +20,14 @@ module.exports = {
 			};
 		}
 
-		const { statusCode, body } = await sb.Got(options);
-		if (statusCode !== 200) {
-			return {
-				success: false,
-				reply: `9GAG API returned error ${statusCode}!`
-			};
-		}
+		const response = await sb.Got("GenericAPI", options);
 
 		const nsfw = Boolean(context.channel?.NSFW);
-		const filtered = (nsfw)
-			? body.data.posts
-			: body.data.posts.filter(i => i.nsfw !== 1);
+		const filteredPosts = (nsfw)
+			? response.body.data.posts
+			: response.body.data.posts.filter(i => i.nsfw !== 1);
 
-		const post = sb.Utils.randArray(filtered);
+		const post = sb.Utils.randArray(filteredPosts);
 		if (!post) {
 			return {
 				success: false,

--- a/commands/dictionary/index.js
+++ b/commands/dictionary/index.js
@@ -30,19 +30,21 @@ module.exports = {
 		}
 
 		const phrase = encodeURIComponent(args.join(" "));
-		const { statusCode, body: data } = await sb.Got({
+		const response = await sb.Got("GenericAPI", {
 			url: `https://api.dictionaryapi.dev/api/v1/entries/en/${phrase}`,
 			throwHttpErrors: false,
 			responseType: "json"
 		});
 
-		if (statusCode !== 200) {
+		if (!response.ok) {
 			return {
 				success: false,
-				reply: data.message
+				reply: response.body.message
 			};
 		}
 
+		/** @type {Array} */
+		const data = response.body;
 		const records = data.flatMap(i => Object.entries(i.meaning));
 		const items = records.flatMap(([type, value]) => value.map(item => ({ type, definition: item.definition })));
 		if (items.length === 0) {

--- a/commands/doesnotexist/index.js
+++ b/commands/doesnotexist/index.js
@@ -69,7 +69,7 @@ module.exports = {
 					)),
 					types: ["artwork", "cat", "horse", "person"],
 					execute: async (context, type) => {
-						const imageData = await sb.Got({
+						const imageData = await sb.Got("GenericAPI", {
 							url: buildURL(type),
 							responseType: "buffer",
 							throwHttpErrors: false

--- a/commands/necrodancer/index.js
+++ b/commands/necrodancer/index.js
@@ -62,7 +62,7 @@ module.exports = {
 				};
 			}
 
-			const result = await sb.Got({
+			const result = await sb.Got("GenericAPI", {
 				url: createURL({
 					command: "reset",
 					zone: args
@@ -156,7 +156,7 @@ module.exports = {
 
 		let result;
 		try {
-			result = await sb.Got({
+			result = await sb.Got("GenericAPI", {
 				url: createURL({
 					link,
 					zone,

--- a/commands/news/rss.js
+++ b/commands/news/rss.js
@@ -32,7 +32,7 @@ module.exports = {
 
 			let feed;
 			try {
-				const xml = await sb.Got(url).text();
+				const xml = await sb.Got("Global", url).text();
 				feed = await sb.Utils.parseRSS(xml);
 			}
 			catch (e) {

--- a/commands/npm/index.js
+++ b/commands/npm/index.js
@@ -16,7 +16,7 @@ module.exports = {
 			};
 		}
 
-		const data = await sb.Got({
+		const data = await sb.Got("FakeAgent", {
 			url: "https://www.npmjs.com/search",
 			method: "GET",
 			headers: {

--- a/commands/ocr/index.js
+++ b/commands/ocr/index.js
@@ -90,7 +90,7 @@ module.exports = {
 			statusCode = cacheData.statusCode;
 		}
 		else {
-			const response = await sb.Got({
+			const response = await sb.Got("GenericAPI", {
 				method: "GET",
 				responseType: "json",
 				throwHttpErrors: false,

--- a/commands/query/index.js
+++ b/commands/query/index.js
@@ -19,7 +19,7 @@ module.exports = {
 		}
 
 		if (context.params.imageSummary) {
-			const response = await sb.Got({
+			const response = await sb.Got("GenericAPI", {
 				url: "http://api.wolframalpha.com/v1/simple",
 				throwHttpErrors: false,
 				responseType: "buffer",
@@ -54,7 +54,7 @@ module.exports = {
 			};
 		}
 		else {
-			const response = await sb.Got({
+			const response = await sb.Got("GenericAPI", {
 				url: "http://api.wolframalpha.com/v1/result",
 				throwHttpErrors: false,
 				responseType: "text",

--- a/commands/randomalbum/index.js
+++ b/commands/randomalbum/index.js
@@ -21,7 +21,7 @@ module.exports = {
 		let retries = 0;
 		while (!data && retries < maxRetries) {
 			const albumID = sb.Utils.random(minID, maxID);
-			const { statusCode, body: albumData } = await sb.Got({
+			const { statusCode, body: albumData } = await sb.Got("GenericAPI", {
 				url: `https://api.genius.com/albums/${albumID}`,
 				responseType: "json",
 				throwHttpErrors: false,

--- a/commands/randomuploadervideo/index.js
+++ b/commands/randomuploadervideo/index.js
@@ -41,7 +41,7 @@ module.exports = {
 			};
 		}
 
-		const authorData = await sb.Got({
+		const authorData = await sb.Got("GenericAPI", {
 			throwHttpErrors: false,
 			responseType: "json",
 			url: "https://www.googleapis.com/youtube/v3/channels",

--- a/commands/subage/index.js
+++ b/commands/subage/index.js
@@ -49,7 +49,7 @@ module.exports = {
 		const channelName = sb.User.normalizeUsername(channel ?? context.channel.Name);
 		const userName = sb.User.normalizeUsername(user ?? context.user.Name);
 
-		const response = await sb.Got({
+		const response = await sb.Got("FakeAgent", {
 			method: "POST",
 			url: "https://gql.twitch.tv/gql",
 			responseType: "json",

--- a/commands/twitchlotto/index.js
+++ b/commands/twitchlotto/index.js
@@ -229,7 +229,7 @@ module.exports = {
 				image = null;
 			}
 			else if (image.Available === null) {
-				const { statusCode } = await sb.Got({
+				const { statusCode } = await sb.Got("GenericAPI", {
 					method: "HEAD",
 					throwHttpErrors: false,
 					followRedirect: false,

--- a/commands/whatanimeisit/index.js
+++ b/commands/whatanimeisit/index.js
@@ -19,7 +19,7 @@ module.exports = {
 
 		// Possible future reference:
 		// POST method with FormData (name: "image") is also possible if working with files
-		const { statusCode, body: data } = await sb.Got({
+		const { statusCode, body: data } = await sb.Got("GenericAPI", {
 			url: "https://api.trace.moe/search",
 			searchParams: {
 				url: link
@@ -89,7 +89,7 @@ module.exports = {
 		const videoLinkKey = { type: "video-link", url: result.video };
 		let videoLink = await this.getCacheData(videoLinkKey);
 		if (!videoLink) {
-			const videoData = await sb.Got({
+			const videoData = await sb.Got("GenericAPI", {
 				url: result.video,
 				responseType: "buffer",
 				throwHttpErrors: false

--- a/commands/wiki/index.js
+++ b/commands/wiki/index.js
@@ -87,7 +87,7 @@ module.exports = {
 			params.append("format", "json");
 			params.append("url", idLink);
 
-			const shortenResponse = await sb.Got({
+			const shortenResponse = await sb.Got("GenericAPI", {
 				method: "POST",
 				responseType: "json",
 				url: "https://meta.wikimedia.org/w/api.php",

--- a/crons/yoink-soundcloud-client-id/index.mjs
+++ b/crons/yoink-soundcloud-client-id/index.mjs
@@ -5,7 +5,7 @@ export const definition = {
 	Defer: null,
 	Type: "All",
 	Code: (async function yoinkSoundcloudClientID () {
-		const { statusCode } = await sb.Got({
+		const { statusCode } = await sb.Got("GenericAPI", {
 			url: "https://api-v2.soundcloud.com/resolve",
 			throwHttpErrors: false,
 			searchParams: {
@@ -25,14 +25,14 @@ export const definition = {
 		const elements = $("body > script[crossorigin]");
 		const scripts = Array.from(elements).map(i => $(i).attr("src"));
 		for (const script of scripts) {
-			const scriptSource = await sb.Got(script).text();
+			const scriptSource = await sb.Got("FakeAgent", script).text();
 			const match = scriptSource.match(/client_id=(\w+?)\W/);
 			if (!match) {
 				continue;
 			}
 
 			const clientID = match[1];
-			const { statusCode } = await sb.Got({
+			const { statusCode } = await sb.Got("GenericAPI", {
 				url: "https://api-v2.soundcloud.com/resolve",
 				throwHttpErrors: false,
 				searchParams: {


### PR DESCRIPTION
If a Got instance is missing from the method call, in case of a request timeout the error is logged as `Internal` which disrupts the process of checking and fixing actual errors. By using an instance they are logged as `External` which is a lot more clear.