### PR TITLE
Add VS16 to relevant emojis in weather module

### DIFF
--- a/commands/weather/index.js
+++ b/commands/weather/index.js
@@ -21,20 +21,20 @@ module.exports = {
 			const remainder = code % 100;
 
 			if (type === 2) {
-				return "⛈";
+				return "⛈\uFE0F";
 			}
 			else if (type === 3) {
-				return "🌧";
+				return "🌧\uFE0F";
 			}
 			else if (type === 5) {
-				return "🌧";
+				return "🌧\uFE0F";
 			}
 			else if (type === 6) {
-				return "🌨";
+				return "🌨\uFE0F";
 			}
 			else if (type === 7) {
 				if (remainder === 1 || remainder === 21 || remainder === 41) {
-					return "🌫";
+					return "🌫\uFE0F";
 				}
 				else if (remainder === 11) {
 					return "🔥💨";
@@ -46,21 +46,21 @@ module.exports = {
 					return "🌋💨";
 				}
 				else if (remainder === 71 || remainder === 81) {
-					return "🌪";
+					return "🌪\uFE0F";
 				}
 			}
 			else if (type === 8) {
 				if (remainder === 0) {
-					return (current?.uvi === 0) ? "🌙" : "☀";
+					return (current?.uvi === 0) ? "🌙" : "☀\uFE0F";
 				}
 				else if (remainder === 1) {
 					return "🌤️";
 				}
 				else if (remainder === 2) {
-					return "🌥";
+					return "🌥\uFE0F";
 				}
 				else {
-					return "️☁";
+					return "️☁\uFE0F";
 				}
 			}
 
@@ -644,7 +644,7 @@ module.exports = {
 
 			if (tags.length > 0) {
 				const plural = (tags.length > 1) ? "s" : "";
-				weatherAlert = `⚠ Weather alert${plural}: ${tags.join(", ")}.`;
+				weatherAlert = `⚠\uFE0F Weather alert${plural}: ${tags.join(", ")}.`;
 			}
 		}
 


### PR DESCRIPTION
Some emojis need variant selector 16 to specify that they should be rendered as emojis. This is relevant for symbols that existed before emojis were around.

Discord used to render these as emojis anyway, but it has since stopped (outside of some weird, glitchy cases), in what I assume was an update to its correctness. I can't speak for other platforms, but they fail to render as emojis (when viewed on Github or VSCode) on Windows as well.

Instead of adding `\uFE0F`, you could also have the actual VS16 in there (like so: ⚠️), but personally I kind of like the explicit reminder of what is happening, as implementations of these emojis continue to have odd behaviour.