### PR TITLE
`$gpt` - Add Nexra API to GPT models

### DIFF
--- a/commands/gpt/config.json
+++ b/commands/gpt/config.json
@@ -30,7 +30,7 @@
         "default": 100,
         "maximum": 500
       },
-      "usageDivisor": 0.4
+      "usageDivisor": 2.5
     },
     "base-davinci": {
       "url": "davinci-002",
@@ -41,10 +41,10 @@
         "default": 100,
         "maximum": 500
       },
-      "usageDivisor": 2
+      "usageDivisor": 0.5
     },
     "turbo": {
-      "url": "gpt-3.5-turbo-1106",
+      "url": "gpt-3.5-turbo-0125",
       "type": "messages",
       "default": true,
       "inputLimit": 1500,
@@ -54,16 +54,17 @@
       },
       "usageDivisor": 1
     },
-    "tester": {
+    "nexra-4": {
       "url": "gpt-4-32k",
       "type": "nexra",
-      "default": true,
-      "inputLimit": 1500,
+      "experimental": true,
+      "default": false,
+      "inputLimit": 5000,
       "outputLimit": {
-        "default": 100,
-        "maximum": 500
+        "default": 5000,
+        "maximum": 5000
       },
-      "usageDivisor": 1
+      "usageDivisor": 10
     },
     "4": {
       "url": "gpt-4-1106-preview",

--- a/commands/gpt/config.json
+++ b/commands/gpt/config.json
@@ -54,6 +54,17 @@
       },
       "usageDivisor": 1
     },
+    "tester": {
+      "url": "gpt-4-32k",
+      "type": "nexra",
+      "default": true,
+      "inputLimit": 1500,
+      "outputLimit": {
+        "default": 100,
+        "maximum": 500
+      },
+      "usageDivisor": 1
+    },
     "4": {
       "url": "gpt-4-1106-preview",
       "type": "messages",

--- a/commands/gpt/gpt-nexra.js
+++ b/commands/gpt/gpt-nexra.js
@@ -1,7 +1,16 @@
 const GptMessages = require("./gpt-messages.js");
 
+const RESTRICTED_CHANNELS = [30, 37, 38];
+
 module.exports = class GptNexra extends GptMessages {
 	static async execute (context, query, modelData) {
+		if (!RESTRICTED_CHANNELS.includes(context.channel?.ID)) {
+			return {
+				success: false,
+				reply: `Usage of this model is restricted to specific channels!`
+			};
+		}
+
 		const response = await sb.Got("GenericAPI", {
 			method: "POST",
 			throwHttpErrors: false,

--- a/commands/gpt/gpt-nexra.js
+++ b/commands/gpt/gpt-nexra.js
@@ -5,6 +5,7 @@ module.exports = class GptNexra extends GptMessages {
 		const response = await sb.Got("GenericAPI", {
 			method: "POST",
 			throwHttpErrors: false,
+			responseType: "text",
 			url: "https://nexra.aryahcr.cc/api/chat/gpt",
 			json: {
 				model: modelData.url,
@@ -15,6 +16,23 @@ module.exports = class GptNexra extends GptMessages {
 				presence_penalty: 0
 			}
 		});
+
+		let i = 0;
+		const text = response.body;
+		while (text[i] !== "{" || i > text.length) {
+			i++;
+		}
+
+		if (text[i] !== "{") {
+			console.warn({ response, text, i });
+
+			return {
+				success: false,
+				reply: `Nexra API returned an invalid response!`
+			};
+		}
+
+		response.body = JSON.parse(text.slice(i));
 
 		return { response };
 	}

--- a/commands/gpt/gpt-nexra.js
+++ b/commands/gpt/gpt-nexra.js
@@ -1,0 +1,32 @@
+const GptMessages = require("./gpt-messages.js");
+
+module.exports = class GptNexra extends GptMessages {
+	static async execute (context, query, modelData) {
+		const response = await sb.Got("GenericAPI", {
+			method: "POST",
+			throwHttpErrors: false,
+			url: "https://nexra.aryahcr.cc/api/chat/gpt",
+			json: {
+				model: modelData.url,
+				prompt: query,
+				markdown: false,
+				top_p: 1,
+				frequency_penalty: 0,
+				presence_penalty: 0
+			}
+		});
+
+		return { response };
+	}
+
+	static extractMessage (response) {
+		return response.body.gpt;
+	}
+
+	static getUsageRecord () { return 0; }
+	static getCompletionTokens () { return 0; }
+	static getPromptTokens () { return 0; }
+	static getProcessingTime () { return null; }
+
+	static setHistory () {}
+};

--- a/commands/gpt/gpt-nexra.js
+++ b/commands/gpt/gpt-nexra.js
@@ -1,8 +1,6 @@
 const GptMessages = require("./gpt-messages.js");
 const GptHistory = require("./history-control.js");
 
-const RESTRICTED_CHANNELS = [30, 37, 38];
-
 module.exports = class GptNexra extends GptMessages {
 	static async getHistory (context) {
 		const { historyMode } = await GptMessages.getHistoryMode(context);
@@ -12,6 +10,13 @@ module.exports = class GptNexra extends GptMessages {
 	}
 
 	static async execute (context, query, modelData) {
+		// !!! TEMPORARY MEASURE !!!
+		const RESTRICTED_CHANNELS = [
+			sb.Channel.get("supinic", "twitch"),
+			sb.Channel.get("pajlada", "twitch"),
+			sb.Channel.get("supibot", "twitch")
+		].map(i => i?.ID).filter(Boolean);
+
 		if (!RESTRICTED_CHANNELS.includes(context.channel?.ID)) {
 			return {
 				success: false,

--- a/commands/gpt/gpt-template.js
+++ b/commands/gpt/gpt-template.js
@@ -92,6 +92,22 @@ module.exports = class GptTemplate {
 		return response.body.usage.total_tokens;
 	}
 
+	static getPromptTokens (response) {
+		return response.body.usage.prompt_tokens;
+	}
+
+	static getCompletionTokens (response) {
+		return response.body.usage.completion_tokens;
+	}
+
+	static getProcessingTime (response) {
+		if (!response.headers["openai-processing-ms"]) {
+			return null;
+		}
+
+		return Number(response.headers["openai-processing-ms"]);
+	}
+
 	static async handleHistoryCommand (context, query) {
 		if (!context.params.history) {
 			return;

--- a/commands/gpt/index.js
+++ b/commands/gpt/index.js
@@ -212,9 +212,13 @@ module.exports = {
 				return `<li><del><b>${capName}</b> (${letter})</del> - model is currently disabled: ${modelData.disableReason ?? "(N/A)"}</li>`;
 			}
 
-			const typeString = `is a <b>${modelData.type}</b> model`;
+			let type = modelData.type;
+			if (type === "nexra") {
+				type = "messages";
+			}
 
 			let priceChangeString = "";
+			const typeString = `is a <b>${type}</b> model`;
 			if (modelData !== defaultModelData) {
 				if (modelData.usageDivisor === 1) {
 					priceChangeString = ` (same price as ${basePriceModel})`;

--- a/commands/gpt/metrics.js
+++ b/commands/gpt/metrics.js
@@ -1,9 +1,7 @@
 const process = (data) => {
-	const { command, context, response, modelData, success } = data;
-	const {
-		prompt_tokens: inputTokens,
-		completion_tokens: outputTokens
-	} = response.body.usage;
+	const { Handler, response, command, context, modelData, success } = data;
+	const inputTokens = Handler.getPromptTokens(response);
+	const outputTokens = Handler.getCompletionTokens(response);
 
 	const labels = {
 		channel: context.channel?.Name ?? "(private)",
@@ -35,9 +33,9 @@ const process = (data) => {
 	outputTokensCounter.inc(labels, outputTokens);
 	usageCounter.inc({ ...labels, success }, 1);
 
-	if (response.headers["openai-processing-ms"]) {
-		const time = Number(response.headers["openai-processing-ms"]);
-		generationHistogram.observe({ model: modelData.name }, time);
+	const processingTime = Handler.getProcessingTime(response);
+	if (processingTime !== null) {
+		generationHistogram.observe({ model: modelData.name }, processingTime);
 	}
 };
 


### PR DESCRIPTION
Add Nexra as another "type" to the models, with its own URL (distinct from OpenAI) and refactor the model template API to allow for different responses, token amounts, and history formats.