### PR TITLE
Refactor Reminders to a split system

### DIFF
--- a/@types/classes/reminder.d.ts
+++ b/@types/classes/reminder.d.ts
@@ -8,7 +8,6 @@ import { User } from "./user";
 
 type ConstructorData = {
 	ID: number;
-	Active: boolean;
 	User_From: User["ID"];
 	User_To: User["ID"];
 	Channel: Channel["ID"];
@@ -70,7 +69,6 @@ export declare class Reminder extends ClassTemplate {
 	static destroy (): void;
 
 	readonly ID: number;
-	readonly Active: boolean;
 	readonly User_From: User["ID"];
 	readonly User_To: User["ID"];
 	readonly Channel: Channel["ID"] | null;

--- a/classes/reminder.js
+++ b/classes/reminder.js
@@ -41,12 +41,6 @@ module.exports = class Reminder extends require("./template.js") {
 		this.ID = data.ID;
 
 		/**
-		 * Whether or not the reminder is still active (primed).
-		 * @type {boolean}
-		 */
-		this.Active = data.Active;
-
-		/**
 		 * The user who set the reminder up.
 		 * Since anonymous reminders are not supported, this cannot be null.
 		 * @type {User["ID"]}
@@ -152,7 +146,6 @@ module.exports = class Reminder extends require("./template.js") {
 					Platform: channelData.Platform.ID,
 					Channel: channelData.ID,
 					Created: new sb.Date(),
-					Active: true,
 					Schedule: null,
 					Text: `You got a scheduled reminder (ID ${this.ID}) while you were AFK: ${message}`,
 					Private_Message: true
@@ -357,9 +350,6 @@ module.exports = class Reminder extends require("./template.js") {
 	/**
 	 * Creates a new Reminder, and saves it to database.
 	 * Used mostly in commands to set up reminders.
-	 * @param {Object} data {@link Reminder}-compliant data
-	 * @param {boolean} [skipChecks = false] If true, skips all reminder checks. This is done for system reminders, so they always go through.
-	 * @return {ReminderCreationResult}
 	 */
 	static async create (data, skipChecks = false) {
 		if (!skipChecks) {

--- a/classes/reminder.js
+++ b/classes/reminder.js
@@ -850,10 +850,24 @@ module.exports = class Reminder extends require("./template.js") {
 			await row.load(ID, true);
 
 			if (row.loaded) {
-				row.values.Active = false;
-				row.values.Cancelled = Boolean(cancelled);
+				const historyRow = await sb.Query.getRow("chat_data", "Reminder_History");
 
-				await row.save({ skipLoad: true });
+				historyRow.setValues({
+					ID,
+					User_From: row.values.User_From,
+					User_To: row.values.User_To,
+					Channel: row.values.Channel,
+					Platform: row.values.Platform,
+					Type: row.values.Type,
+					Text: row.values.Text,
+					Created: row.values.Created,
+					Schedule: row.values.Schedule,
+					Private_Message: row.values.Private_Message,
+					Cancelled: Boolean(cancelled)
+				});
+
+				await historyRow.save({ skipLoad: true });
+				await row.delete();
 			}
 		}
 

--- a/commands/check/subcommands.js
+++ b/commands/check/subcommands.js
@@ -548,6 +548,17 @@ module.exports = (command) => [
 					.single()
 					.flat("ID")
 				);
+
+				// If no active reminder found, check the historic table
+				identifier ??= await sb.Query.getRecordset(rs => rs
+					.select("ID")
+					.from("chat_data", "Reminder_History")
+					.where("User_From = %n", context.user.ID)
+					.orderBy("ID DESC")
+					.limit(1)
+					.single()
+					.flat("ID")
+				);
 			}
 
 			const ID = Number(identifier);

--- a/commands/check/subcommands.js
+++ b/commands/check/subcommands.js
@@ -600,6 +600,7 @@ module.exports = (command) => [
 
 			let status = "";
 			if (!active) {
+				// Only applies to Reminder_History table
 				status = (reminder.Cancelled) ? "(cancelled)" : "(inactive)";
 			}
 

--- a/commands/check/subcommands.js
+++ b/commands/check/subcommands.js
@@ -561,26 +561,34 @@ module.exports = (command) => [
 				};
 			}
 
-			const reminder = await sb.Query.getRecordset(rs => rs
-				.select("ID", "User_From", "User_To", "Text", "Active", "Schedule", "Cancelled")
-				.from("chat_data", "Reminder")
-				.where("ID = %n", ID)
-				.single()
-			);
+			// Load active reminder
+			let active = true;
+			let row = await sb.Query.getRow("chat_data", "Reminder");
+			await row.load(ID, true);
 
-			if (!reminder) {
+			// If active reminder does not exist, fall back to historic table
+			if (!row.loaded) {
+				active = false;
+				row = await sb.Query.getRow("chat_data", "Reminder_History");
+				await row.load(ID, true);
+			}
+
+			// If still nothing exists, error out
+			if (!row.loaded) {
 				return {
 					reply: "That reminder doesn't exist!"
 				};
 			}
-			else if (reminder.User_From !== context.user.ID && reminder.User_To !== context.user.ID) {
+
+			const reminder = row.valuesObject;
+			if (reminder.User_From !== context.user.ID && reminder.User_To !== context.user.ID) {
 				return {
 					reply: "That reminder was not created by you or for you. Stop peeking!"
 				};
 			}
 
 			let status = "";
-			if (!reminder.Active) {
+			if (!active) {
 				status = (reminder.Cancelled) ? "(cancelled)" : "(inactive)";
 			}
 

--- a/commands/set/subcommands/reminder.js
+++ b/commands/set/subcommands/reminder.js
@@ -25,21 +25,25 @@ module.exports = {
 		await row.load(ID, true);
 
 		if (!row.loaded) {
-			return {
-				success: false,
-				reply: "That reminder does not exist!"
-			};
+			const historyRow = await sb.Query.getRow("chat_data", "Reminder_History");
+			await historyRow.load(ID, true);
+			if (historyRow.loaded) {
+				return {
+					success: false,
+					reply: "That reminder is already deactivated!"
+				};
+			}
+			else {
+				return {
+					success: false,
+					reply: "There is no reminder with such ID!"
+				};
+			}
 		}
 		else if (row.values.User_From !== context.user.ID && row.values.User_To !== context.user.ID) {
 			return {
 				success: false,
 				reply: "That reminder was not created by you or set for you!"
-			};
-		}
-		else if (!row.values.Active) {
-			return {
-				success: false,
-				reply: "That reminder is already deactivated!"
 			};
 		}
 		else if (context.channel?.ID && !row.values.Schedule && row.values.User_To === context.user.ID) {

--- a/commands/set/subcommands/reminder.js
+++ b/commands/set/subcommands/reminder.js
@@ -22,17 +22,15 @@ module.exports = {
 	}),
 	unset: async (context, ID) => {
 		const row = await sb.Query.getRow("chat_data", "Reminder");
-		try {
-			await row.load(ID);
-		}
-		catch {
+		await row.load(ID, true);
+
+		if (!row.loaded) {
 			return {
 				success: false,
-				reply: "ID does not exist!"
+				reply: "That reminder does not exist!"
 			};
 		}
-
-		if (row.values.User_From !== context.user.ID && row.values.User_To !== context.user.ID) {
+		else if (row.values.User_From !== context.user.ID && row.values.User_To !== context.user.ID) {
 			return {
 				success: false,
 				reply: "That reminder was not created by you or set for you!"

--- a/commands/statistics/types/reminders.js
+++ b/commands/statistics/types/reminders.js
@@ -3,19 +3,32 @@ module.exports = {
 	aliases: ["reminders"],
 	description: "Shows how many times you or someone else have used reminders.",
 	execute: async (context) => {
-		const data = await sb.Query.getRecordset(rs => rs
-			.select("SUM(Schedule IS NULL) AS Unscheduled")
-			.select("SUM(Schedule IS NOT NULL) AS Scheduled")
-			.from("chat_data", "Reminder")
-			.where("User_From = %n", context.user.ID)
-			.single()
-		);
+		const [liveData, historyData] = await Promise.all([
+			sb.Query.getRecordset(rs => rs
+				.select("SUM(Schedule IS NULL) AS Unscheduled")
+				.select("SUM(Schedule IS NOT NULL) AS Scheduled")
+				.from("chat_data", "Reminder")
+				.where("User_From = %n", context.user.ID)
+				.single()
+			),
+			sb.Query.getRecordset(rs => rs
+				.select("SUM(Schedule IS NULL) AS Unscheduled")
+				.select("SUM(Schedule IS NOT NULL) AS Scheduled")
+				.from("chat_data", "Reminder_History")
+				.where("User_From = %n", context.user.ID)
+				.single()
+			)
+		]);
+
+		const unscheduled = liveData.Unscheduled + historyData.Unscheduled;
+		const scheduled = liveData.Scheduled + historyData.Scheduled;
+		const total = unscheduled + scheduled;
 
 		return {
 			reply: sb.Utils.tag.trim `
-				So far, you have created ${data.Unscheduled} direct reminders
-				and ${data.Scheduled} timed reminders,
-				for a total of ${data.Unscheduled + data.Scheduled}.
+				So far, you have created ${unscheduled} direct reminders
+				and ${scheduled} timed reminders,
+				for a total of ${total}.
 			`
 		};
 	}

--- a/platforms/discord.js
+++ b/platforms/discord.js
@@ -445,6 +445,9 @@ module.exports = class DiscordPlatform extends require("./template.js") {
 				else if (!skipGlobalEmotes && GLOBAL_EMOTE_ALLOWED_REGEX.test(word) && word.length > 2) {
 					emote = sb.Utils.randArray(eligibleEmotes);
 				}
+				else {
+					continue;
+				}
 
 				// This regex makes sure all emotes to be replaces are not preceded or followed by a ":" (colon) character
 				// All emotes on Discord are wrapped at least by colons


### PR DESCRIPTION
Premise:
Since reminder history is accessed infrequently and is unused at startup, it makes little sense to slow down the startup by filtering through all the inactive reminders in the database.

Goals:
- improve on-load speed and overall database performance
- aim is to split the `Reminder` table into `Reminder` and `Reminder_History`
- remove the Active flag column completely, this will be determined by each table itself
- refactor commands, classes and tables to allow for this structure