### PR TITLE
Fix possible `$roll` range

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,2 @@
 enableGlobalCache: true
 nodeLinker: node-modules
-checksumBehavior: ignore

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,3 @@
 enableGlobalCache: true
 nodeLinker: node-modules
+checksumBehavior: ignore

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "discord.js": "^14.15.3",
     "irc-framework": "^4.13.1",
     "language-iso-codes": "supinic/language-iso-codes#master",
-    "roll-dice": "npm:@jprochazk/roll-dice@^0.2.2",
+    "roll-dice": "npm:@jprochazk/roll-dice@^0.4.0",
     "rss-parser": "^3.13.0",
     "supi-core": "supinic/supi-core",
     "track-link-parser": "supinic/track-link-parser#master",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "discord.js": "^14.15.3",
     "irc-framework": "^4.13.1",
     "language-iso-codes": "supinic/language-iso-codes#master",
-    "roll-dice": "npm:@jprochazk/roll-dice@^0.4.1",
+    "roll-dice": "npm:@jprochazk/roll-dice@^0.4.2",
     "rss-parser": "^3.13.0",
     "supi-core": "supinic/supi-core",
     "track-link-parser": "supinic/track-link-parser#master",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "discord.js": "^14.15.3",
     "irc-framework": "^4.13.1",
     "language-iso-codes": "supinic/language-iso-codes#master",
-    "roll-dice": "npm:@jprochazk/roll-dice@^0.4.0",
+    "roll-dice": "npm:@jprochazk/roll-dice@^0.4.1",
     "rss-parser": "^3.13.0",
     "supi-core": "supinic/supi-core",
     "track-link-parser": "supinic/track-link-parser#master",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "allowJs": true,
     "alwaysStrict": true,
     "checkJs": false,
+    "declaration": true,
     "emitDeclarationOnly": true
   },
   "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,10 +3998,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"roll-dice@npm:@jprochazk/roll-dice@^0.4.1":
-  version: 0.4.1
-  resolution: "@jprochazk/roll-dice@npm:0.4.1"
-  checksum: 10c0/ac9d1600e594de53eb155ce1351f5448a209fb08095c71ecabbf074e2e58b9472746554bebd0bb9a88a1bc66c3e37203795c683f49e88cbe36eea89e2de9beba
+"roll-dice@npm:@jprochazk/roll-dice@^0.4.2":
+  version: 0.4.2
+  resolution: "@jprochazk/roll-dice@npm:0.4.2"
+  checksum: 10c0/571a3e35691f4080a588e61640b7d1fb27a46fdd603c9867dd4d93fd3673d336e3c23abcc1a0a87c183f9ae6c7380cd946fa998235e31902fd7fba00b26fe971
   languageName: node
   linkType: hard
 
@@ -4399,7 +4399,7 @@ supi-core@supinic/supi-core:
     language-iso-codes: "supinic/language-iso-codes#master"
     mocha: "npm:^10.5.2"
     nyc: "npm:^17.0.0"
-    roll-dice: "npm:@jprochazk/roll-dice@^0.4.1"
+    roll-dice: "npm:@jprochazk/roll-dice@^0.4.2"
     rss-parser: "npm:^3.13.0"
     supi-core: supinic/supi-core
     supi-db-init: "Supinic/supi-db-init#master"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,10 +3998,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"roll-dice@npm:@jprochazk/roll-dice@^0.4.0":
-  version: 0.4.0
-  resolution: "@jprochazk/roll-dice@npm:0.4.0"
-  checksum: 10c0/b69289404308f87a6df09b0ecffd8bc3e5f4137fd69bd07c108f74ae1f7ddd82b3f7e3024ff3b38826a3f7ec3d166283238309388ca6e9b6d28cb13923982320
+"roll-dice@npm:@jprochazk/roll-dice@^0.4.1":
+  version: 0.4.1
+  resolution: "@jprochazk/roll-dice@npm:0.4.1"
+  checksum: 10c0/ac9d1600e594de53eb155ce1351f5448a209fb08095c71ecabbf074e2e58b9472746554bebd0bb9a88a1bc66c3e37203795c683f49e88cbe36eea89e2de9beba
   languageName: node
   linkType: hard
 
@@ -4399,7 +4399,7 @@ supi-core@supinic/supi-core:
     language-iso-codes: "supinic/language-iso-codes#master"
     mocha: "npm:^10.5.2"
     nyc: "npm:^17.0.0"
-    roll-dice: "npm:@jprochazk/roll-dice@^0.4.0"
+    roll-dice: "npm:@jprochazk/roll-dice@^0.4.1"
     rss-parser: "npm:^3.13.0"
     supi-core: supinic/supi-core
     supi-db-init: "Supinic/supi-db-init#master"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,10 +3998,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"roll-dice@npm:@jprochazk/roll-dice@^0.2.2":
-  version: 0.2.2
-  resolution: "@jprochazk/roll-dice@npm:0.2.2"
-  checksum: 10c0/a965ad013f65db12320fdc0e0331d806aa23693a73c2c43f1eca0ccf6d5ab307f6a728a84e22ca5c71debdc7c63fbae224b15d4c59412b82ab2998c6c460377f
+"roll-dice@npm:@jprochazk/roll-dice@^0.4.0":
+  version: 0.4.0
+  resolution: "@jprochazk/roll-dice@npm:0.4.0"
+  checksum: 10c0/b69289404308f87a6df09b0ecffd8bc3e5f4137fd69bd07c108f74ae1f7ddd82b3f7e3024ff3b38826a3f7ec3d166283238309388ca6e9b6d28cb13923982320
   languageName: node
   linkType: hard
 
@@ -4399,7 +4399,7 @@ supi-core@supinic/supi-core:
     language-iso-codes: "supinic/language-iso-codes#master"
     mocha: "npm:^10.5.2"
     nyc: "npm:^17.0.0"
-    roll-dice: "npm:@jprochazk/roll-dice@^0.2.2"
+    roll-dice: "npm:@jprochazk/roll-dice@^0.4.0"
     rss-parser: "npm:^3.13.0"
     supi-core: supinic/supi-core
     supi-db-init: "Supinic/supi-db-init#master"


### PR DESCRIPTION
## Changes

This PR bumps the version of the `@jprochazk/roll-dice` package to `0.4.2`.

## Explanation

Currently, a roll like `$roll 1000000d3` will always result in a value around 1.3 million. The underlying PRNG has a uniform distribution, so due to the law of large numbers, the result will tend towards the middle of the range.

I'm not an expert on statistics, but the issue seems to be that the range which is being sampled is _not_ `[1,3]` but `[1,3)`, meaning the result can never be `3`, and so the distribution shifts towards the `1`. Or in other words, an off-by-one error.

The newest version of `@jprochazk/roll-dice` fixes that by properly sampling from `[1, 3]` for each `Nd3` roll, so `3` is a possible value. A roll like `$roll 1000000d3` will now result in a value around 2 million.

I tested the result using a simple REPL for the library. With a working installation of Rust and Cargo, you can run the REPL like so:

```
git clone https://github.com/jprochazk/roll-dice`
cd roll-dice
cargo run -p roll
```

It accepts the same expressions that you'd pass to `$roll`.