### PR TITLE
`poe` Gem changes per patch 3.25

### DIFF
--- a/commands/poe/gems.json
+++ b/commands/poe/gems.json
@@ -12,14 +12,6 @@
     "type": "additional"
   },
   {
-    "name": "Ancestral Protector",
-    "type": "main"
-  },
-  {
-    "name": "Ancestral Warchief",
-    "type": "main"
-  },
-  {
     "name": "Anger",
     "type": "additional"
   },
@@ -192,6 +184,10 @@
     "type": "main"
   },
   {
+    "name": "Crushing Fist",
+    "type": "additional"
+  },
+  {
     "name": "Cyclone",
     "type": "main"
   },
@@ -244,6 +240,10 @@
     "type": "main"
   },
   {
+    "name": "Divine Retribution",
+    "type": "additional"
+  },
+  {
     "name": "Dominating Blow",
     "type": "main"
   },
@@ -294,6 +294,10 @@
   {
     "name": "Ethereal Knives",
     "type": "main"
+  },
+  {
+    "name": "Eviscerate",
+    "type": "additional"
   },
   {
     "name": "Explosive Arrow",
@@ -410,6 +414,10 @@
   {
     "name": "Glacial Hammer",
     "type": "main"
+  },
+  {
+    "name": "Glacial Shield Swipe",
+    "type": "additional"
   },
   {
     "name": "Grace",
@@ -1064,6 +1072,10 @@
     "type": "additional"
   },
   {
+    "name": "Vengeful Cry",
+    "type": "additional"
+  },
+  {
     "name": "Venom Gyre",
     "type": "main"
   },
@@ -1611,6 +1623,11 @@
   },
   {
     "name": "Molten Strike of the Zenith",
+    "type": "main",
+    "transfigured": true
+  },
+  {
+    "name": "Puncture of Shanking",
     "type": "main",
     "transfigured": true
   },

--- a/commands/poe/gems.json
+++ b/commands/poe/gems.json
@@ -680,20 +680,12 @@
     "type": "main"
   },
   {
-    "name": "Reckoning",
-    "type": "additional"
-  },
-  {
     "name": "Rejuvenation Totem",
     "type": "additional"
   },
   {
     "name": "Righteous Fire",
     "type": "main"
-  },
-  {
-    "name": "Riposte",
-    "type": "additional"
   },
   {
     "name": "Scorching Ray",
@@ -1066,10 +1058,6 @@
   {
     "name": "Vaal Summon Skeletons",
     "type": "main"
-  },
-  {
-    "name": "Vengeance",
-    "type": "additional"
   },
   {
     "name": "Vengeful Cry",


### PR DESCRIPTION
- Ancestral Warchief and Ancestral Protector gems have been removed
- Retribution skills have been added as "additional" skills
- Puncture of Shanking has been added to transfigured gems