### PR TITLE
Remove db table command

### DIFF
--- a/classes/command.js
+++ b/classes/command.js
@@ -426,24 +426,6 @@ class Command extends require("./template.js") {
 				console.warn(`Removed duplicate command name "${dupe}" from command ${command.Name}'s aliases`);
 			}
 		}
-
-		const addMissingRowsPromises = Command.data.map(async (commandData) => {
-			const row = await sb.Query.getRow("chat_data", "Command");
-			await row.load(commandData.Name, true);
-
-			if (!row.loaded) {
-				row.setValues({
-					Name: commandData.Name,
-					Aliases: (commandData.Aliases.length !== 0)
-						? JSON.stringify(commandData.Aliases)
-						: null
-				});
-
-				await row.save({ skipLoad: true });
-			}
-		});
-
-		await Promise.all(addMissingRowsPromises);
 	}
 
 	static get (identifier) {

--- a/init/definitions/chat_data/tables/Command.sql
+++ b/init/definitions/chat_data/tables/Command.sql
@@ -1,8 +1,0 @@
-CREATE TABLE IF NOT EXISTS `chat_data`.`Command` (
-	`Name` VARCHAR(50) NOT NULL COLLATE 'utf8mb4_general_ci',
-	`Aliases` TEXT(65535) NULL DEFAULT NULL COMMENT 'JSON array of strings that will be this command\'s aliases.' COLLATE 'utf8mb4_general_ci',
-	PRIMARY KEY `Name` (`Name`) USING BTREE
-)
-COLLATE='utf8mb4_general_ci'
-ENGINE=InnoDB
-DEFAULT CHARSET=utf8mb4;;

--- a/init/definitions/chat_data/tables/Command_Execution.sql
+++ b/init/definitions/chat_data/tables/Command_Execution.sql
@@ -11,11 +11,10 @@ CREATE TABLE IF NOT EXISTS `chat_data`.`Command_Execution` (
   `Result` VARCHAR(300) NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
   PRIMARY KEY (`User_Alias`, `Command`, `Executed`, `Platform`) USING BTREE,
   INDEX `Command_Execution_Platform` (`Platform`) USING BTREE,
-  INDEX `FK_Command_Execution_Command` (`Command`) USING BTREE,
+  INDEX `Command_Execution_Command` (`Command`) USING BTREE,
   INDEX `FK_Command_Execution_Channel` (`Channel`) USING BTREE,
   INDEX `Executed` (`Executed`) USING BTREE,
   CONSTRAINT `FK_Command_Execution_Channel` FOREIGN KEY (`Channel`) REFERENCES `chat_data`.`Channel` (`ID`) ON UPDATE CASCADE ON DELETE CASCADE,
-  CONSTRAINT `FK_Command_Execution_Command` FOREIGN KEY (`Command`) REFERENCES `chat_data`.`Command` (`Name`) ON UPDATE CASCADE ON DELETE CASCADE,
   CONSTRAINT `FK_Command_Execution_User_Alias` FOREIGN KEY (`User_Alias`) REFERENCES `chat_data`.`User_Alias` (`ID`) ON UPDATE CASCADE ON DELETE CASCADE
 )
 COLLATE='utf8mb4_general_ci'

--- a/init/definitions/chat_data/tables/Filter.sql
+++ b/init/definitions/chat_data/tables/Filter.sql
@@ -16,16 +16,14 @@ CREATE TABLE IF NOT EXISTS `chat_data`.`Filter` (
   `Changed` DATETIME(3) NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP(3),
   `Notes` text DEFAULT NULL,
   PRIMARY KEY (`ID`),
-  UNIQUE KEY `User_Alias_Channel_Command` (`User_Alias`,`Channel`,`Command`,`Type`,`Blocked_User`,`Platform`,`Invocation`) USING BTREE,
+  INDEX `Filter_Command` (`Command`) USING BTREE,
   INDEX `Filter_Platform` (`Platform`) USING BTREE,
   KEY `FK_Ban_Channel` (`Channel`),
-  KEY `FK_Ban_Command` (`Command`),
   KEY `FK_Ban_User_Alias_2` (`Issued_By`),
   KEY `FK_Filter_User_Alias` (`Blocked_User`),
   KEY `Active_Lookup` (`Active`),
   CONSTRAINT `FK_Filter_User_Alias` FOREIGN KEY (`Blocked_User`) REFERENCES `User_Alias` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `Filter_ibfk_1` FOREIGN KEY (`Channel`) REFERENCES `Channel` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `Filter_ibfk_2` FOREIGN KEY (`Command`) REFERENCES `Command` (`Name`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `Filter_ibfk_3` FOREIGN KEY (`User_Alias`) REFERENCES `User_Alias` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `Filter_ibfk_4` FOREIGN KEY (`Issued_By`) REFERENCES `User_Alias` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
 )

--- a/init/setup.js
+++ b/init/setup.js
@@ -264,13 +264,6 @@
 
 		const filteredCommands = ["ban", "debug", "reload"];
 		for (const command of filteredCommands) {
-			const commandRow = await sb.Query.getRow("chat_data", "Command");
-			await commandRow.load(command, true);
-			if (!commandRow.loaded) {
-				commandRow.values.Name = command;
-				await commandRow.save({ skipLoad: true });
-			}
-
 			const filterExists = await sb.Query.getRecordset(rs => rs
 				.select("ID")
 				.from("chat_data", "Filter")


### PR DESCRIPTION
Removes the `chat_data.Command` table from all database definitions, foreign keys (still keeps it as index) and from the bot's usage.

The table has been redundant for quite some time and only used as a "sanity" check for manual editing of the database. This really shouldn't be a problem anymore.