### PR TITLE
chore: Update `raccatta.cc` -> `awoo.nl`

### DIFF
--- a/commands/whatemoteisit/index.js
+++ b/commands/whatemoteisit/index.js
@@ -132,7 +132,7 @@ module.exports = {
 			};
 		}
 		else {
-			const emoteLink = `https://emotes.raccatta.cc/twitch/emote/${emoteID}`;
+			const emoteLink = `https://emotes.awoo.nl/twitch/emote/${emoteID}`;
 			return {
 				reply: `${emoteCode} - ID ${emoteID} - ${active} ${tierString}. ${emoteLink} ${cdnLink} ${originString}`
 			};


### PR DESCRIPTION
Avoids the current redirect. The old domain's not set to renew anymore afaik.