### PR TITLE
Use escapeMarkdown from discord.js instead of putting messages into code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cron": "^4.3.0",
     "cytube-connector": "supinic/cytube-connector",
     "discord.js": "^14.18.0",
+    "@discordjs/formatters": "^0.6.0",
     "irc-framework": "^4.14.0",
     "rss-parser": "^3.13.0",
     "supi-core": "supinic/supi-core",

--- a/platforms/discord.ts
+++ b/platforms/discord.ts
@@ -13,7 +13,8 @@ import {
 	PermissionFlagsBits,
 	Routes,
 	TextChannel,
-	User as DiscordUser
+	User as DiscordUser,
+	escapeMarkdown
 } from "discord.js";
 
 import { BaseConfig, Platform, PlatformVerificationStatus, PrepareMessageOptions } from "./template.js";
@@ -75,20 +76,6 @@ const formatEmoji = (emote: Emote) => {
 	}
 	else {
 		return `<:${name}:${emote.ID}>`;
-	}
-};
-const fixMarkdown = (text: string) => {
-	let isMarkdown = false;
-	for (const regex of Object.values(MARKDOWN_TESTS)) {
-		isMarkdown ||= regex.test(text);
-	}
-
-	if (!isMarkdown) {
-		return text;
-	}
-	else {
-		const replaced = text.replaceAll("```", "`\u{200B}`\u{200B}`\u{200B}");
-		return `\`\`\`${replaced}\`\`\``;
 	}
 };
 
@@ -240,7 +227,7 @@ export class DiscordPlatform extends Platform<DiscordConfig> {
 			});
 		}
 
-		const fixed = (typeof sendTarget === "string") ? fixMarkdown(sendTarget) : sendTarget;
+		const fixed = (typeof sendTarget === "string") ? escapeMarkdown(sendTarget) : sendTarget;
 		try {
 			await channelObject.send(fixed);
 			this.incrementMessageMetric("sent", channelData);
@@ -307,7 +294,7 @@ export class DiscordPlatform extends Platform<DiscordConfig> {
 
 		try {
 			if (typeof message === "string") {
-				const fixed = fixMarkdown(message);
+				const fixed = escapeMarkdown(message);
 				await discordUser.send(fixed);
 			}
 			else if (options.embeds && options.embeds.length !== 0) {
@@ -351,7 +338,7 @@ export class DiscordPlatform extends Platform<DiscordConfig> {
 		}
 
 		try {
-			const fixed = fixMarkdown(message);
+			const fixed = escapeMarkdown(message);
 			await discordUser.send(fixed);
 			this.incrementMessageMetric("sent", null);
 		}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4893,6 +4893,7 @@ supi-db-init@supinic/supi-db-init:
   dependencies:
     "@babel/core": "npm:^7.26.10"
     "@babel/eslint-parser": "npm:^7.27.0"
+    "@discordjs/formatters": "npm:^0.6.0"
     "@jprochazk/roll-dice": "npm:^0.4.2"
     acorn-node: "npm:^2.0.1"
     async-markov: supinic/async-markov


### PR DESCRIPTION
Discord.js provides an `escapeMarkdown` function specifically for the purpose that the code blocks were there for. It's split into a separate npm package under the discord.js library, so it had to be added to package.json.

I haven't tested this as I do not have discord bot dev set up atm, but this should be a straightforward enough change.