### PR TITLE
Fix deduplication not working with hyphen in content

### DIFF
--- a/commands/news/google-news.js
+++ b/commands/news/google-news.js
@@ -58,8 +58,12 @@ export default {
 
 		let result;
 		const dashlessTitle = title.replaceAll("-", "").replaceAll(/\s+/g, " ");
-		if (dashlessTitle.includes(content) || content.includes(dashlessTitle)) {
+		const dashlessContent = content.replaceAll("-", "").replaceAll(/\s+/g, " ");
+		if (dashlessTitle.includes(dashlessContent)) {
 			result = `${title ?? ""} ${delta}`;
+		}
+		else if (dashlessContent.includes(dashlessTitle)) {
+			result = `${content ?? ""} ${delta}`;
 		}
 		else {
 			result = `${title ?? ""}${separator}${content ?? ""} ${delta}`;


### PR DESCRIPTION
The original deduplication is removing all hyphens from the title. Seemingly this is a workaround to an API quirk where often the title and the body are the same, except that the title has a hyphen between the text and the name of the publication. But if there are any hyphens in the actual text as well, those will be removed too, causing it to fail the comparison to the body (which kept its hyphens).

I chose to solve this by removing hyphens from both.

In addition, I interpreted the two `.includes` tests as suggesting that either one could be the one that has additional information. I don't know if that is correct, but just in case, I made it use the longer one (post-filtering hyphens and excess whitespace) of the two.

Feel free to delete this last part.