### PR TITLE
Don't use `.sort` to find the top value

### DIFF
--- a/commands/news/google-news.js
+++ b/commands/news/google-news.js
@@ -47,7 +47,11 @@ export default {
 		}));
 
 		const article = (context.params.latest)
-			? articles.sort((a, b) => b.published - a.published)[0]
+			? articles.reduce((acc, article) => {
+				(article.published > acc.published)
+				? article
+				: acc
+			})
 			: core.Utils.randArray(articles);
 
 		const { content, title, published } = article;


### PR DESCRIPTION
Sorting a whole list to find only the top item (by some metric) is wasteful. `.reduce` does the same job but without comparing all the losing values to each other.

`.sort` is used this way in other places but I couldn't be bothered to find them all. I figured I'd just do the one in the file I was already touching.

I did not test this or format this or even run any basic syntax check. I'm editing from the Github website. I do not recommend this experience and I hope you have automated testing.