### PR TITLE
`$urban` - fix API inaccuracy + rewrite to TS

### DIFF
--- a/commands/urban/index.js
+++ b/commands/urban/index.js
@@ -1,7 +1,8 @@
 const URBAN_FAUX_ACCESS_KEY = "ab71d33b15d36506acf1e379b0ed07ee";
 const prepareItemStrings = (item) => {
 	const url = new URL(item.permalink);
-	const id = url.pathname.replace("/", "");
+	// const id = url.pathname.replace("/", ""); // Looks like this no longer works as of cca. 2025-07-06
+	const id = url.searchParams.get("defid");
 	const link = `https://urbanup.com/${id}`;
 
 	const thumbs = `(+${item.thumbs_up}/-${item.thumbs_down})`;


### PR DESCRIPTION
- since 2025-07-06, the API no longer returns expected format of `permalink`
- since the same time, it also doesn't provide any vote numbers, not sure why
  - this is reflected in the API
  - also reflected on the website...? as in, nothing has any votes anymore, all terms are 0/0