### PR TITLE
`$subscribe` add arch linux RSS feed

### DIFF
--- a/commands/subscribe/event-types/archlinux.ts
+++ b/commands/subscribe/event-types/archlinux.ts
@@ -1,0 +1,18 @@
+import { RssEventDefinition } from "../generic-event.js";
+
+export default {
+	name: "Arch Linux",
+	aliases: ["arch", "archlinux"],
+	notes: "Posts new Arch Linux news articles whenever one is published",
+	channelSpecificMention: true,
+	response: {
+		added: "You will now be pinged whenever a new Arch Linux article is published.",
+		removed: "You will no longer receive pings when a new Arch Linux article is published."
+	},
+	generic: true,
+	cronExpression: "0 */5 * * * *",
+	subName: "Arch Linux article",
+	type: "rss",
+	cacheKey: "archlinux-article-last-publish-date",
+	url: "https://archlinux.org/feeds/news/"
+} satisfies RssEventDefinition;

--- a/commands/subscribe/event-types/index.ts
+++ b/commands/subscribe/event-types/index.ts
@@ -1,5 +1,6 @@
 import { GenericEventDefinition, SpecialEventDefinition } from "../generic-event.js";
 
+import ArchLinuxSubDefinition from "./archlinux.js";
 import BrighterShoresSubDefinition from "./brighter-shores.js";
 import BunSubDefinition from "./bun.js";
 import ChangelogSubDefinition from "./changelog.js";
@@ -19,6 +20,7 @@ import SuggestionSubDefinition from "./suggestion.js";
 import V8SubDefinition from "./v8.js";
 
 export default [
+	ArchLinuxSubDefinition,
 	BrighterShoresSubDefinition,
 	BunSubDefinition,
 	ChangelogSubDefinition,


### PR DESCRIPTION
This PR aims to add the Arch Linux news feed to the list of subscribable events. This feed is RSS and has a very low publishing rate, so the cron expression could be lowered if you want.

Code untested, will give it a test before it's merged (unless you're happy with it since it's a clone of the bun subscription.) 