### PR TITLE
Refactor `CooldownManager` - remove Interval

### DIFF
--- a/classes/command.ts
+++ b/classes/command.ts
@@ -1376,8 +1376,6 @@ export class Command extends TemplateWithoutId {
 		for (const command of Command.data.values()) {
 			command.destroy();
 		}
-
-		Command.#cooldownManager.destroy();
 	}
 
 	static get prefixRegex () {


### PR DESCRIPTION
Refactor the class in any way that will keep the current functionality and API (mostly) intact, while also removing the pruning `setInterval`. This interval is pesky in multiple scenarios - it hangs the NodeJS process once all other execution is finished.