### PR TITLE
Add Zod for external data validation

### DIFF
--- a/commands/9gag/index.ts
+++ b/commands/9gag/index.ts
@@ -1,27 +1,28 @@
 import { SupiDate } from "supi-core";
 import { declare } from "../../classes/command.js";
+import * as z from "zod";
 
-type NineGagData = {
-	data: {
-		posts: {
-			title: string;
-			nsfw: 0 | 1;
-			creationTs: number;
-			upVoteCount: number;
-			id: string;
-		}[];
-	};
-};
+const NineGagData = z.object({
+	data: z.object({
+		posts: z.array(z.object({
+			title: z.string(),
+			nsfw: z.literal([0, 1]),
+			creationTs: z.int(),
+			upVoteCount: z.int(),
+			id: z.string(),
+		}))
+	})
+})
 
 export default declare({
 	Name: "9gag",
 	Aliases: ["gag"],
 	Cooldown: 10_000,
 	Description: "Searches 9gag for posts that fit your search text, or a random featured one if you don't provide anything.",
-	Flags: ["external-input","mention","non-nullable","pipe"],
+	Flags: ["external-input", "mention", "non-nullable", "pipe"],
 	Params: [],
 	Whitelist_Response: null,
-	Code: async function nineGag (context, ...args) {
+	Code: async function nineGag(context, ...args) {
 		const options = (args.length === 0)
 			? { url: "https://9gag.com/v1/group-posts/group/default/type/hot" }
 			: {
@@ -31,12 +32,13 @@ export default declare({
 				})
 			};
 
-		const response = await core.Got.get("GenericAPI")<NineGagData>(options);
+		const response = await core.Got.get("GenericAPI")(options);
+		const body = NineGagData.parse(response.body);
 
 		const nsfw = Boolean(context.channel?.NSFW);
 		const filteredPosts = (nsfw)
-			? response.body.data.posts
-			: response.body.data.posts.filter(i => i.nsfw !== 1);
+			? body.data.posts
+			: body.data.posts.filter(i => i.nsfw !== 1);
 
 		if (filteredPosts.length === 0) {
 			return {

--- a/commands/randomline/rustlog.ts
+++ b/commands/randomline/rustlog.ts
@@ -1,5 +1,6 @@
 import { SupiDate, SupiError } from "supi-core";
 import config from "../../config.json" with { type: "json" };
+import * as z from "zod";
 
 type InstancesDefinition = Record<string, {
 	url: string;
@@ -20,22 +21,25 @@ for (const [name, def] of Object.entries(instances)) {
 
 if (!defaultInstance) {
 	throw new SupiError({
-	    message: "Assert error: No default Rustlog instance set"
+		message: "Assert error: No default Rustlog instance set"
 	});
 }
 
 type InstanceChannelMap = Record<string, string[]>;
-type ChannelListResponse = {
-	channels: { name: string; userID: string; }[];
-};
-type RandomLineResponse = {
-	messages: {
-		text: string;
-		displayName: string;
-		timestamp: string;
-		username: string;
-	}[];
-};
+const ChannelListResponse = z.object({
+	channels: z.array(z.object({
+		name: z.string(),
+		userID: z.string()
+	})),
+});
+
+const Message = z.object({
+	text: z.string(),
+	displayName: z.string(),
+	timestamp: z.iso.datetime(),
+	username: z.string(),
+});
+const LogsResponse = z.object({ messages: z.array(Message).min(1) });
 
 const channelInstanceMap: Map<string, string> = new Map();
 const getChannelLoggingInstances = async function () {
@@ -46,7 +50,7 @@ const getChannelLoggingInstances = async function () {
 
 	const result: InstanceChannelMap = {};
 	const promises = Object.entries(instances).map(async ([instanceKey, instance]) => {
-		const response = await core.Got.get("GenericAPI")<ChannelListResponse>({
+		const response = await core.Got.get("GenericAPI")({
 			url: `https://${instance.url}/channels`,
 			throwHttpErrors: false,
 			timeout: {
@@ -58,7 +62,7 @@ const getChannelLoggingInstances = async function () {
 			return;
 		}
 
-		const { channels } = response.body;
+		const { channels } = ChannelListResponse.parse(response.body);
 		result[instanceKey] = channels.map(i => i.userID);
 	});
 
@@ -111,13 +115,13 @@ export const getRandomChannelLine = async function (channelId: string): Promise<
 	const instanceName = await getInstance(channelId);
 	if (!instanceName) {
 		throw new SupiError({
-		    message: "Assert error: No instance name found for existing channel",
+			message: "Assert error: No instance name found for existing channel",
 			args: { channelId }
 		});
 	}
 
 	const instance = instances[instanceName];
-	const response = await core.Got.get("GenericAPI")<RandomLineResponse>({
+	const response = await core.Got.get("GenericAPI")({
 		url: `https://${instance.url}/channelid/${channelId}/random`,
 		throwHttpErrors: false,
 		searchParams: {
@@ -144,7 +148,7 @@ export const getRandomChannelLine = async function (channelId: string): Promise<
 		};
 	}
 
-	const message = response.body.messages.at(0);
+	const message = LogsResponse.parse(response.body).messages.at(0);
 	if (!message) {
 		return {
 			success: false,
@@ -170,7 +174,7 @@ export const getRandomUserLine = async function (channelId: string, userId: stri
 	}
 
 	const instance = instances[instanceName];
-	const response = await core.Got.get("GenericAPI")<RandomLineResponse>({
+	const response = await core.Got.get("GenericAPI")({
 		url: `https://${instance.url}/channelid/${channelId}/userid/${userId}/random`,
 		throwHttpErrors: false,
 		searchParams: {
@@ -197,7 +201,7 @@ export const getRandomUserLine = async function (channelId: string, userId: stri
 		};
 	}
 
-	const [message] = response.body.messages;
+	const [message] = LogsResponse.parse(response.body).messages;
 	return {
 		success: true,
 		date: new SupiDate(message.timestamp),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "track-link-parser": "supinic/track-link-parser",
     "transliteration": "^2.3.5",
     "vm2": "^3.9.19",
-    "ws": "^8.18.3"
+    "ws": "^8.18.3",
+    "zod": "^4.0.17"
   },
   "engines": {
     "node": ">= 24.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5208,6 +5208,7 @@ supi-db-init@supinic/supi-db-init:
     typescript-eslint: "npm:^8.39.0"
     vm2: "npm:^3.9.19"
     ws: "npm:^8.18.3"
+    zod: "npm:^4.0.17"
   languageName: unknown
   linkType: soft
 
@@ -5875,5 +5876,12 @@ track-link-parser@supinic/track-link-parser:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
+  languageName: node
+  linkType: hard
+
+"zod@npm:^4.0.17":
+  version: 4.0.17
+  resolution: "zod@npm:4.0.17"
+  checksum: 10c0/c56ef4cc02f8f52be8724c5a8b338266202d68477c7606bee9b7299818b75c9adc27f16f4b6704a372f3e7578bd016f389de19bfec766564b7c39d0d327c540a
   languageName: node
   linkType: hard


### PR DESCRIPTION
This PR adds [Zod](https://zod.dev/), a library for validating external data against a defined schema. Currently all API responses are coerced into TS types with no checking, which is unsafe. See the documentation of Zod for more information on how it works.

Here it is added for 9gag and rustlog APIs as an example of how it works. The TS schema definitions have to be changed into zod objects (so the validation may be performed at runtime), but you don't lose any TS benefits as zod types get an automatically inferred matching TS type.

Example validation error for a malformed 9gag schema:
```json
  {
    "expected": "number",
    "code": "invalid_type",
    "path": [
      "data",
      "posts",
      2,
      "title"
    ],
    "message": "Invalid input: expected number, received string"
  }
```
It would be very nice if we could integrate this into most places that operate on external data, including the config (so it doesn't have to be embedded at compile time anymore).