### PR TITLE
Rewrite `$steamgameplayers` to TS + use Zod

### DIFF
--- a/commands/steamgameplayers/index.ts
+++ b/commands/steamgameplayers/index.ts
@@ -1,9 +1,25 @@
 import { CronJob } from "cron";
+import { SupiDate, SupiError } from "supi-core";
+import * as z from "zod";
 
+import { declare } from "../../classes/command.js";
+
+const SteamAppSchema = z.object({
+	apps: z.array(
+		z.object({
+			appid: z.int(),
+			last_modified: z.int(),
+			name: z.string(),
+			price_change_number: z.int()
+		})
+	),
+	have_more_results: z.boolean(),
+	last_appid: z.int()
+});
 const fetchGamesData = async () => {
-	let lastUpdate = await core.Cache.getByPrefix("latest-steam-games-update");
+	let lastUpdate = await core.Cache.getByPrefix("latest-steam-games-update") as number | undefined;
 	if (!lastUpdate) {
-		lastUpdate = new sb.Date().addHours(-24).getTime() / 1000;
+		lastUpdate = new SupiDate().addHours(-24).getTime() / 1000;
 	}
 
 	const response = await core.Got.get("GenericAPI")({
@@ -17,9 +33,10 @@ const fetchGamesData = async () => {
 		}
 	});
 
-	await core.Cache.setByPrefix("latest-steam-games-update", sb.Date.now() / 1000);
+	const { apps } = SteamAppSchema.parse(response.body);
+	await core.Cache.setByPrefix("latest-steam-games-update", SupiDate.now() / 1000);
 
-	for (const game of response.body.response.apps) {
+	for (const game of apps) {
 		const row = await core.Query.getRow("data", "Steam_Game");
 		await row.load(game.appid, true);
 		if (row.loaded && game.name === row.values.Name) {
@@ -35,7 +52,19 @@ const fetchGamesData = async () => {
 	}
 };
 
-const fetchReviewData = async (gameId) => {
+// Currently unused
+/*
+const SteamReviewSchema = z.object({
+	query_summary: z.object({
+		num_reviews: z.int().min(0),
+		review_score: z.int().min(0),
+		total_negative: z.int().min(0),
+		total_positive: z.int().min(0),
+		total_reviews: z.int().min(0),
+		review_score_desc: z.string()
+	})
+});
+const fetchReviewData = async (gameId: string | number) => {
 	const response = await core.Got.get("GenericAPI")({
 		url: `https://store.steampowered.com/appreviews/${gameId}`,
 		searchParams: {
@@ -47,7 +76,7 @@ const fetchReviewData = async (gameId) => {
 
 	let reviewsString;
 	if (response.ok) {
-		const summary = response.body.query_summary;
+		const { query_summary: summary } = SteamReviewSchema.parse(response.body);
 		if (summary.total_reviews > 0) {
 			const score = core.Utils.round(summary.total_positive / summary.total_reviews * 100, 1);
 			reviewsString = `Rating: ${summary.review_score_desc} (${score}% positive)`;
@@ -64,18 +93,31 @@ const fetchReviewData = async (gameId) => {
 		result: reviewsString
 	};
 };
+*/
 
-const fetchRecommendationData = async (gameId) => {
+const SteamRecommendationSchema = z.object({
+	success: z.union([z.literal(0), z.literal(1)]),
+	results: z.object({
+		rollups: z.array(
+			z.object({
+				recommendations_up: z.int().min(0),
+				recommendations_down: z.int().min(0)
+			})
+		)
+	}).optional()
+});
+const fetchRecommendationData = async (gameId: string | number) => {
 	const response = await core.Got.get("GenericAPI")({
 		url: `https://store.steampowered.com/appreviewhistogram/${gameId}`
 	});
 
-	if (!response.ok || response.body.success !== 1) {
+	const { success, results } = SteamRecommendationSchema.parse(response.body);
+	if (!response.ok || success !== 1) {
 		return {
 			result: "Could not fetch reviews data!"
 		};
 	}
-	else if (!response.body.results || !response.body.results.rollups) {
+	else if (!results) {
 		return {
 			result: "This game has no reviews!"
 		};
@@ -83,9 +125,15 @@ const fetchRecommendationData = async (gameId) => {
 
 	let up = 0;
 	let down = 0;
-	for (const item of response.body.results.rollups) {
+	for (const item of results.rollups) {
 		up += item.recommendations_up;
 		down += item.recommendations_down;
+	}
+
+	if ((up + down) === 0) {
+		return {
+			result: "This game has no reviews with ratings!"
+		};
 	}
 
 	const value = core.Utils.round(up / (up + down) * 100, 2);
@@ -94,29 +142,46 @@ const fetchRecommendationData = async (gameId) => {
 	};
 };
 
-export default {
+const SteamPlayerCountSchema = z.object({
+	response: z.object({
+		player_count: z.number().min(0)
+	})
+});
+
+const SteamGameDataSchema = z.record(
+	z.string(),
+	z.object({
+		success: z.boolean(),
+		data: z.object({
+			name: z.string(),
+			developers: z.array(z.string())
+		})
+	}).optional()
+);
+
+let updateCronJob: CronJob | null = null;
+export default declare({
 	Name: "steamgameplayers",
 	Aliases: ["sgp"],
-	Author: "supinic",
 	Cooldown: 5000,
 	Description: "Searches for a Steam game, and attempts to find its current player amount.",
 	Flags: ["mention","pipe"],
 	Params: [
 		{ name: "gameID", type: "number" },
 		{ name: "skipReviews", type: "boolean" }
-	],
+	] as const,
 	Whitelist_Response: null,
 	initialize: function () {
-		this.data.updateCronJob = new CronJob("0 0 * * * *", () => fetchGamesData());
-		this.data.updateCronJob.start();
+		updateCronJob = new CronJob("0 0 * * * *", () => fetchGamesData());
+		updateCronJob.start();
 	},
 	destroy: function () {
-		this.data.updateCronJob.stop();
-		this.data.updateCronJob = null;
+		void updateCronJob?.stop();
+		updateCronJob = null;
 	},
 	Code: async function steamGamePlayers (context, ...args) {
-		if (!process.env.API_CRYPTO_COMPARE) {
-			throw new sb.Error({
+		if (!process.env.API_STEAM_KEY) {
+			throw new SupiError({
 				message: "No Steam key configured (API_STEAM_KEY)"
 			});
 		}
@@ -136,7 +201,7 @@ export default {
 				gameId = Number(potentialUrlAppId[1]);
 			}
 			else {
-				const plausibleResults = await core.Query.getRecordset(rs => {
+				const plausibleResults = await core.Query.getRecordset<{ ID: number, Name: string }[]>(rs => {
 					rs.select("ID", "Name");
 					rs.from("data", "Steam_Game");
 					rs.limit(25);
@@ -157,12 +222,29 @@ export default {
 				}
 
 				const plausibleNames = plausibleResults.map(i => i.Name);
-				const [bestMatch] = core.Utils.selectClosestString(gameName, plausibleNames, {
+				const matchResult = core.Utils.selectClosestString(gameName, plausibleNames, {
 					ignoreCase: true,
 					fullResult: true
 				});
+				if (!matchResult || matchResult.length === 0) {
+					throw new SupiError({
+					    message: "Assert error: Queried Steam game not found by string"
+					});
+				}
 
-				gameId = plausibleResults.find(i => i.Name === bestMatch.original).ID;
+				const [bestMatch] = matchResult;
+				const foundGame = (
+					plausibleResults.find(i => i.Name === gameName) // Try and find the case identical to user input first
+					?? plausibleResults.find(i => i.Name === bestMatch.original) // default to best match second
+				);
+
+				if (!foundGame) {
+					throw new SupiError({
+						message: "Assert error: Queried Steam game not found by results"
+					});
+				}
+
+				gameId = foundGame.ID;
 			}
 		}
 
@@ -182,6 +264,7 @@ export default {
 			};
 		}
 
+		const { response: playerCountData } = SteamPlayerCountSchema.parse(playerCountResponse.body);
 		const gameDataResponse = await core.Got.get("GenericAPI")({
 			url: "https://store.steampowered.com/api/appdetails",
 			throwHttpErrors: false,
@@ -190,21 +273,22 @@ export default {
 			}
 		});
 
-		let publisher = "";
-		const gameData = gameDataResponse.body[gameId]?.data;
-		if (!gameData) {
+		const gameSchema = SteamGameDataSchema.parse(gameDataResponse.body)[gameId];
+		if (!gameSchema || !gameSchema.success) {
 			return {
 				success: false,
 				reply: "This Steam game supposedly exists, but there is no data associated with it!"
 			};
 		}
 
+		const { data: gameData } = gameSchema;
+		let publisher = "";
 		const devs = gameData.developers;
 		if (Array.isArray(devs)) {
 			if (devs.length === 1) {
 				publisher = `(by ${devs[0]})`;
 			}
-			else if (devs > 1) {
+			else if (devs.length > 1) {
 				publisher = `(by ${devs[0]} and others)`;
 			}
 		}
@@ -216,39 +300,38 @@ export default {
 		}
 
 		const steamLink = `https://store.steampowered.com/app/${gameId}`;
-		const players = playerCountResponse.body.response.player_count;
 		return {
 			reply: core.Utils.tag.trim `
 				${gameData.name} ${publisher}
 				currently has
-				${core.Utils.groupDigits(players)}
+				${core.Utils.groupDigits(playerCountData.player_count)}
 				players in-game.
 				${reviewsString}	
 				${steamLink}	
 			`
 		};
 	},
-	Dynamic_Description: async () => [
+	Dynamic_Description: (prefix) => [
 		"Fetches the current amount of players for a specific Steam game.",
 		"",
 
-		`<code>$sgp (game name)</code>`,
-		`<code>$sgp Counter Strike</code>`,
+		`<code>${prefix}steamgameplayers Counter Strike</code>`,
+		`<code>${prefix}sgp (game name)</code>`,
+		`<code>${prefix}sgp Counter Strike</code>`,
 		"Fetches game data by its name",
 		"",
 
-		`<code>$sgp (steam store URL)</code>`,
-		`<code>$sgp https://store.steampowered.com/app/105600/Terraria</code>`,
+		`<code>${prefix}sgp (steam store URL)</code>`,
+		`<code>${prefix}sgp https://store.steampowered.com/app/105600/Terraria</code>`,
 		"Fetches game data by its Steam Store URL (and some others too possibly)",
 		"",
 
-		`<code>$sgp gameID:(game ID)</code>`,
-		`<code>$sgp gameID:12345</code>`,
+		`<code>${prefix}sgp gameID:(game ID)</code>`,
+		`<code>${prefix}sgp gameID:12345</code>`,
 		"Fetches game data by its Steam ID",
 		"",
 
-		`<code>$sgp skipReviews:true (game)</code>`,
-		"If provided with the <code>skipReviews</code> parameter, the command will not show the game's reviews score.",
-		""
+		`<code>${prefix}sgp skipReviews:true (game)</code>`,
+		"If provided with the <code>skipReviews</code> parameter, the command will not show the game's reviews score."
 	]
-};
+});

--- a/commands/steamgameplayers/index.ts
+++ b/commands/steamgameplayers/index.ts
@@ -55,49 +55,6 @@ const fetchGamesData = async () => {
 	}
 };
 
-// Currently unused
-/*
-const SteamReviewSchema = z.object({
-	query_summary: z.object({
-		num_reviews: z.int().min(0),
-		review_score: z.int().min(0),
-		total_negative: z.int().min(0),
-		total_positive: z.int().min(0),
-		total_reviews: z.int().min(0),
-		review_score_desc: z.string()
-	})
-});
-const fetchReviewData = async (gameId: string | number) => {
-	const response = await core.Got.get("GenericAPI")({
-		url: `https://store.steampowered.com/appreviews/${gameId}`,
-		searchParams: {
-			json: "1",
-			filter: "all",
-			language: "all"
-		}
-	});
-
-	let reviewsString;
-	if (response.ok) {
-		const { query_summary: summary } = SteamReviewSchema.parse(response.body);
-		if (summary.total_reviews > 0) {
-			const score = core.Utils.round(summary.total_positive / summary.total_reviews * 100, 1);
-			reviewsString = `Rating: ${summary.review_score_desc} (${score}% positive)`;
-		}
-		else {
-			reviewsString = `Rating: ${summary.review_score_desc}`;
-		}
-	}
-	else {
-		reviewsString = "Could not fetch reviews data";
-	}
-
-	return {
-		result: reviewsString
-	};
-};
-*/
-
 const SteamRecommendationSchema = z.object({
 	success: z.union([z.literal(0), z.literal(1)]),
 	results: z.object({


### PR DESCRIPTION
- Rewrite to TS
- Use Zod to validate all the Steam (Steam shop) APIs
- try and include some kind of heuristic for finding games exactly as the user types them
- fix the unlikely but sometimes possible case when there's a non-zero amount of reviews, but their total score (positive + negative) is still zero