### PR TITLE
Clean up error logs

### DIFF
--- a/commands/news/rss.js
+++ b/commands/news/rss.js
@@ -52,18 +52,13 @@ export default {
 				feed = await parseRSS(xml);
 			}
 			catch (e) {
-				const err = new SupiError({
+				const wrapErr = new SupiError({
 					message: "RSS fetching/parsing failed",
 					cause: e
 				});
-
-				await logger.logError("Command", err, {
-					origin: "Internal",
-					context: {
-						code: news.code,
-						url,
-						source
-					}
+				void logger.logError("Command", wrapErr, {
+					origin: "External",
+					context: { code: news.code, url, source }
 				});
 
 				return {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -65,15 +65,9 @@ export default tseslint.config(
 			"lines-between-class-members": ["warn", "always", {
 				exceptAfterSingleLine: true
 			}],
-			"max-nested-callbacks": ["warn", {
-				max: 2
-			}],
-			"max-params": ["warn", {
-				max: 5
-			}],
-			"max-statements-per-line": ["error", {
-				max: 1
-			}],
+			"max-nested-callbacks": ["warn", { max: 3 }],
+			"max-params": ["warn", { max: 5 }],
+			"max-statements-per-line": ["error", { max: 1 }],
 			"multiline-ternary": ["warn", "always-multiline"],
 			"new-cap": ["warn", {
 				capIsNew: false,

--- a/gots/global/index.ts
+++ b/gots/global/index.ts
@@ -1,17 +1,25 @@
 import { Agent } from "http2-wrapper";
 import type { Http2Session } from "node:http2";
-import { isGotRequestError, type GotInstanceDefinition } from "supi-core";
+import type { GotInstanceDefinition } from "supi-core";
 
 import { getConfig } from "../../config.js";
-import { logger } from "../../singletons/logger.js";
 const { defaultUserAgent } = getConfig().modules.gots;
 
 const agent = new Agent({
-	maxEmptySessions: 100,
+	timeout: 15_000,
+	maxEmptySessions: 25,
 	maxCachedTlsSessions: 250
 });
+
 agent.on("session", (session: Http2Session) => {
-	session.on("goaway", () => session.destroy());
+	session.once("goaway", () => {
+		session.close();
+		setTimeout(() => {
+			if (!session.destroyed && !session.closed) {
+				session.destroy();
+			}
+		}, 30_000).unref();
+	});
 });
 
 export default {
@@ -22,7 +30,7 @@ export default {
 		http2: true,
 		agent: { http2: agent },
 		retry: {
-			limit: 0
+			limit: 2
 		},
 		timeout: {
 			request: 30000
@@ -39,28 +47,7 @@ export default {
 			beforeRetry: [],
 			beforeRequest: [],
 			init: [],
-			beforeError: [
-				async (err) => {
-					if (!isGotRequestError(err)) {
-						return err;
-					}
-					else if (err.code !== "ETIMEDOUT") {
-						return err;
-					}
-
-					await logger.logError("Request", err, {
-						origin: "External",
-						context: {
-							code: err.code,
-							responseType: err.options.responseType,
-							timeout: err.options.timeout,
-							url: err.options.url?.toString() ?? null
-						}
-					});
-
-					return err;
-				}
-			]
+			beforeError: []
 		}
 	})),
 	parent: null,

--- a/master.ts
+++ b/master.ts
@@ -223,10 +223,7 @@ process.on("unhandledRejection", (reason) => {
 		return;
 	}
 
-	const origin = (reason.message.includes("RequestError: Timeout awaiting 'request'"))
-		? "External"
-		: "Internal";
-
+	const origin = (reason.message.includes("RequestError")) ? "External" : "Internal";
 	void logger.logError("Backend", reason, {
 		origin,
 		context: {

--- a/platforms/discord.ts
+++ b/platforms/discord.ts
@@ -381,6 +381,10 @@ export class DiscordPlatform extends Platform<DiscordConfig> {
 		if (IGNORED_CHANNEL_TYPES.has(channelType)) {
 			return;
 		}
+		// Do not process empty messages (parseMessage does take attachments into account)
+		else if (!msg) {
+			return;
+		}
 
 		// If the bot does not have SEND_MESSAGES permission in the channel, completely ignore the message.
 		// Do not process it for logging, commands, AFKs, Reminders, anything.
@@ -394,19 +398,7 @@ export class DiscordPlatform extends Platform<DiscordConfig> {
 		// eslint-disable-next-line @typescript-eslint/no-misused-spread
 		const usernameCharacterLength = [...user].length;
 		if (usernameCharacterLength > 32) {
-			const json = JSON.stringify({
-				chan,
-				discordID,
-				guildName: guild?.name ?? null,
-				guildMembers: guild?.memberCount ?? null,
-				msg,
-				messageID: messageObject.id,
-				author: messageObject.author,
-				user,
-				userLength: user.length
-			});
-
-			await logger.log("Discord.Warning", `Discord username length > 32 characters: ${json}`);
+			// usually happens for compound channel announcement "users", don't process and skip
 			return;
 		}
 
@@ -509,23 +501,7 @@ export class DiscordPlatform extends Platform<DiscordConfig> {
 			this.resolveUserMessage(channelData, userData, msg);
 
 			if (channelData.Logging.has("Meta")) {
-				if (!msg) {
-					const obj = {
-						channel: channelData.Name,
-						guild: guild.id,
-						messageObject
-					};
-
-					await logger.log(
-						"Discord.Warning",
-						`No message text on Discord: ${JSON.stringify(obj)}`,
-						channelData,
-						userData
-					);
-				}
-				else {
-					logger.updateLastSeen({ channelData, userData, message: msg });
-				}
+				logger.updateLastSeen({ channelData, userData, message: msg });
 			}
 			if (this.logging.messages && channelData.Logging.has("Lines")) {
 				await logger.push(core.Utils.wrapString(msg, this.messageLimit), userData, channelData);
@@ -867,7 +843,7 @@ export class DiscordPlatform extends Platform<DiscordConfig> {
 			return this.#emoteFetchingPromise;
 		}
 
-		this.#emoteFetchingPromise = (async (): Promise<Emote[]> => {
+		this.#emoteFetchingPromise = (async () => {
 			const result = [];
 			const guilds = await this.client.guilds.fetch();
 
@@ -890,7 +866,7 @@ export class DiscordPlatform extends Platform<DiscordConfig> {
 			}
 
 			this.#emoteFetchingPromise = null;
-			return result;
+			return result satisfies Emote[];
 		})();
 
 		return await this.#emoteFetchingPromise;

--- a/platforms/discord.ts
+++ b/platforms/discord.ts
@@ -228,34 +228,28 @@ export class DiscordPlatform extends Platform<DiscordConfig> {
 			});
 		}
 
+		let success = false;
 		const fixed = (typeof sendTarget === "string") ? escapeMarkdown(sendTarget) : sendTarget;
 		try {
 			await channelObject.send(fixed);
-			this.incrementMessageMetric("sent", channelData);
+			success = true;
 		}
 		catch (e) {
-			const errorContext = {
-				hasEmbeds: Boolean(options.embeds),
-				channelID: channelObject.id,
-				channelName: channelObject.name,
-				guildID: channelObject.guild.id,
-				guildName: channelObject.guild.name
-			};
+			const cause = (e instanceof Error) ? e : new Error(String(e));
+			await logger.logError("Backend", cause, {
+				origin: "External",
+				context: {
+					hasEmbeds: Boolean(options.embeds),
+					channelID: channelObject.id,
+					channelName: channelObject.name,
+					guildID: channelObject.guild.id,
+					guildName: channelObject.guild.name
+				}
+			});
+		}
 
-			if (e instanceof DiscordAPIError) {
-				await logger.logError("Backend", e, {
-					origin: "External",
-					context: errorContext
-				});
-			}
-			else {
-				const cause = (e instanceof Error) ? e : new Error(String(e));
-				throw new SupiError({
-					message: "Sending Discord channel message failed",
-					args: errorContext,
-					cause
-				});
-			}
+		if (success) {
+			this.incrementMessageMetric("sent", channelData);
 		}
 	}
 

--- a/platforms/discord.ts
+++ b/platforms/discord.ts
@@ -228,15 +228,13 @@ export class DiscordPlatform extends Platform<DiscordConfig> {
 			});
 		}
 
-		let success = false;
 		const fixed = (typeof sendTarget === "string") ? escapeMarkdown(sendTarget) : sendTarget;
 		try {
 			await channelObject.send(fixed);
-			success = true;
 		}
 		catch (e) {
 			const cause = (e instanceof Error) ? e : new Error(String(e));
-			await logger.logError("Backend", cause, {
+			void logger.logError("Backend", cause, {
 				origin: "External",
 				context: {
 					hasEmbeds: Boolean(options.embeds),
@@ -246,11 +244,10 @@ export class DiscordPlatform extends Platform<DiscordConfig> {
 					guildName: channelObject.guild.name
 				}
 			});
+			return;
 		}
 
-		if (success) {
-			this.incrementMessageMetric("sent", channelData);
-		}
+		this.incrementMessageMetric("sent", channelData);
 	}
 
 	/**
@@ -274,17 +271,15 @@ export class DiscordPlatform extends Platform<DiscordConfig> {
 			discordUser = await this.client.users.fetch(userData.Discord_ID);
 		}
 		catch (e) {
-			const cause = (e instanceof Error) ? e : new Error(String(e));
-			throw new SupiError({
+			const wrapErr = new SupiError({
 				message: "Cannot send private message: Discord user does not exist",
-				args: {
-					message,
-					discordUserID: userData.Discord_ID,
-					userID: userData.ID,
-					userName: userData.Name
-				},
-				cause
+				cause: (e instanceof Error) ? e : new Error(String(e))
 			});
+			void logger.logError("Backend", wrapErr, {
+				context: { user: userData.ID, username: userData.Name, message },
+				origin: "External"
+			});
+			return;
 		}
 
 		try {
@@ -297,58 +292,59 @@ export class DiscordPlatform extends Platform<DiscordConfig> {
 					embeds: options.embeds
 				});
 			}
-
-			this.incrementMessageMetric("sent", null);
 		}
 		catch (e) {
-			const cause = (e instanceof Error) ? e : new Error(String(e));
-			throw new SupiError({
-				message: "Sending Discord private message failed",
-				args: {
-					message,
-					userName: userData.Name,
-					userID: userData.ID,
-					discordUserID: userData.Discord_ID
-				},
-				cause
+			const wrapErr = new SupiError({
+				message: "CanSending Discord private message failed",
+				cause: (e instanceof Error) ? e : new Error(String(e))
 			});
+			void logger.logError("Backend", wrapErr, {
+				context: { user: userData.ID, username: userData.Name, message },
+				origin: "External"
+			});
+			return;
 		}
+
+		this.incrementMessageMetric("sent", null);
 	}
 
 	/**
 	 * Directly sends a private message to user, without them necessarily being saved as a user.
 	 */
-	async directPm (userID: string, message: string) {
+	async directPm (userID: string, message: string): Promise<void> {
 		let discordUser;
 		try {
 			discordUser = await this.client.users.fetch(userID);
 		}
 		catch (e) {
-			const cause = (e instanceof Error) ? e : new Error(String(e));
-			throw new SupiError({
+			const wrapErr = new SupiError({
 				message: "Cannot send direct private message: Discord user does not exist",
-				args: { message, userID },
-				cause
+				cause: (e instanceof Error) ? e : new Error(String(e))
 			});
+			void logger.logError("Backend", wrapErr, {
+				context: { userID, message },
+				origin: "External"
+			});
+			return;
 		}
 
 		try {
 			const fixed = escapeMarkdown(message);
 			await discordUser.send(fixed);
-			this.incrementMessageMetric("sent", null);
 		}
 		catch (e) {
-			const cause = (e instanceof Error) ? e : new Error(String(e));
-			throw new SupiError({
+			const wrapErr = new SupiError({
 				message: "Sending direct Discord private message failed",
-				args: {
-					message,
-					discordUserName: discordUser.username,
-					discordUserID: userID
-				},
-				cause
+				cause: (e instanceof Error) ? e : new Error(String(e))
 			});
+			void logger.logError("Backend", wrapErr, {
+				context: { userID, message },
+				origin: "External"
+			});
+			return;
 		}
+
+		this.incrementMessageMetric("sent", null);
 	}
 
 	async handleMessage (messageObject: DiscordMessage) {

--- a/platforms/twitch-utils.ts
+++ b/platforms/twitch-utils.ts
@@ -663,6 +663,8 @@ const fetchExistingSubscriptions = async (): Promise<EnabledSubscription[]> => {
 
 	const result: EnabledSubscription[] = [...response.body.data];
 	let cursor: string | null = response.body.pagination.cursor ?? null;
+	let retries = 0;
+
 	while (cursor) {
 		const loopResponse = await core.Got.get("GenericAPI")<ListSubscriptionsResponse>({
 			url: "https://api.twitch.tv/helix/eventsub/subscriptions",
@@ -684,7 +686,15 @@ const fetchExistingSubscriptions = async (): Promise<EnabledSubscription[]> => {
 			cursor = loopResponse.body.pagination.cursor ?? null;
 		}
 		else {
-			await logger.log(
+			if (retries > 3) {
+				throw new SupiError({
+					message: "Too many subscription fetch failures",
+					args: { body: loopResponse.body }
+				});
+			}
+
+			retries++;
+			void logger.log(
 				"Twitch.Warning",
 				`Subscription fetch failed or is incompatible: ${response.statusCode}; ${JSON.stringify(response.body)}`
 			);

--- a/platforms/twitch-utils.ts
+++ b/platforms/twitch-utils.ts
@@ -1,4 +1,5 @@
 import { SupiError } from "supi-core";
+import { logger } from "../singletons/logger.js";
 
 import type { TwitchPlatform } from "./twitch.js";
 import type { User } from "../classes/user.js";
@@ -678,8 +679,16 @@ const fetchExistingSubscriptions = async (): Promise<EnabledSubscription[]> => {
 			}
 		});
 
-		result.push(...loopResponse.body.data);
-		cursor = loopResponse.body.pagination.cursor ?? null;
+		if (response.ok || !Array.isArray(loopResponse.body.data)) {
+			result.push(...loopResponse.body.data);
+			cursor = loopResponse.body.pagination.cursor ?? null;
+		}
+		else {
+			await logger.log(
+				"Twitch.Warning",
+				`Subscription fetch failed or is incompatible: ${response.statusCode}; ${JSON.stringify(response.body)}`
+			);
+		}
 	}
 
 	return result;

--- a/singletons/mpv-client.ts
+++ b/singletons/mpv-client.ts
@@ -199,7 +199,7 @@ export class MpvClient {
 		}
 
 		if (skip) {
-			await this.send(["playlist-remove", 0]);
+			await this.send(["playlist-remove", 0], true);
 			await this.saveCache();
 			setTimeout(() => void this.play(), 2000);
 		}


### PR DESCRIPTION
Either reduce/remove redundant error logging to the `Error` table, or at least change the errors' `Origin` value to `"External"` if it truly has nothing to do with the bot's runtime.