### PR TITLE
Switch cryptocurrency APIs to `CryptoGecko`

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -37,7 +37,7 @@
 # API_KEY_DEEPINFRA=
 
 ## Crypto
-# API_CRYPTO_COMPARE=
+# API_CRYPTO_GECKO=
 # API_FIXER_IO=
 
 ## Pastebin

--- a/commands/crypto/index.ts
+++ b/commands/crypto/index.ts
@@ -34,7 +34,6 @@ export default declare({
 			url: "https://api.coingecko.com/api/v3/simple/price",
 			searchParams: {
 				symbols: symbol,
-				names: symbol,
 				vs_currencies: "USD,EUR"
 			},
 			headers: {

--- a/commands/crypto/index.ts
+++ b/commands/crypto/index.ts
@@ -2,13 +2,15 @@ import * as z from "zod";
 import { SupiError } from "supi-core";
 import { declare } from "../../classes/command.js";
 
-const cryptoSchema = z.union([
-	z.object({ Response: z.literal("Error"), Message: z.string() }),
+// nonexistent symbol = empty object as response
+// otherwise, the record keys will be the requested symbols
+const cryptoSchema = z.record(
+	z.string(),
 	z.object({
-		USD: z.number().optional(),
-		EUR: z.number().optional()
+		usd: z.number().optional(),
+		eur: z.number().optional()
 	})
-]);
+);
 
 export default declare({
 	Name: "crypto",
@@ -19,40 +21,41 @@ export default declare({
 	Flags: ["mention", "non-nullable", "pipe"],
 	Params: [],
 	Whitelist_Response: null,
-	Code: (async function crypto (context, symbol = "BTC") {
-		if (!process.env.API_CRYPTO_COMPARE) {
+	Code: (async function crypto (context, symbol = "btc") {
+		if (!process.env.API_CRYPTO_GECKO) {
 			throw new SupiError({
-				message: "No CryptoCompare key configured (API_CRYPTO_COMPARE)"
+				message: "No CryptoCompare key configured (API_CRYPTO_GECKO)"
 			});
 		}
 
 		symbol = symbol.toUpperCase();
 
 		const response = await core.Got.get("GenericAPI")({
-			url: "https://min-api.cryptocompare.com/data/price",
+			url: "https://api.coingecko.com/api/v3/simple/price",
 			searchParams: {
-				fsym: symbol,
-				tsyms: "USD,EUR"
-			},
-			timeout: {
-				request: 10000
+				symbols: symbol,
+				names: symbol,
+				vs_currencies: "USD,EUR"
 			},
 			headers: {
-				Authorization: `Apikey ${process.env.API_CRYPTO_COMPARE}`
+				"x-cg-demo-api-key": process.env.API_CRYPTO_GECKO
 			}
 		});
 
-		const data = cryptoSchema.parse(response.body);
-		if ("Response" in data) {
+		const apiData = cryptoSchema.parse(response.body);
+		const symbolKey = Object.keys(apiData).at(0);
+		if (!symbolKey) {
 			return {
 				success: false,
-				reply: `Could not fetch price data! Error: ${data.Message}`
+				reply: `Your provided symbol was not found on the CryptoGecko API!`
 			};
 		}
-		else if (!data.USD && !data.EUR) {
+
+		const data = apiData[symbolKey];
+		if (!data.usd && !data.eur) {
 			return {
 				success: false,
-				reply: `No known prices found for that currency!`
+				reply: `No known prices found for that cryptocurrency!`
 			};
 		}
 
@@ -74,7 +77,13 @@ export default declare({
 					}
 				});
 
-				url = response.url;
+				const coin = response.url.split("/").at(-1);
+				if (coin) {
+					url = `https://www.coingecko.com/en/coins/${coin}`;
+				}
+				else {
+					url = response.url;
+				}
 			}
 			catch {
 				url = null;
@@ -85,8 +94,8 @@ export default declare({
 			? `Check recent history for ${symbol} here: ${url}`
 			: "";
 
-		const usd = (data.USD) ? `$${data.USD}` : "";
-		const eur = (data.EUR) ? `€${data.EUR}` : "";
+		const usd = (data.usd) ? `$${data.usd}` : "";
+		const eur = (data.eur) ? `€${data.eur}` : "";
 		return {
 			success: true,
 			reply: `Current price of ${symbol}: ${usd} ${eur} ${link}`,

--- a/commands/cryptogame/README.md
+++ b/commands/cryptogame/README.md
@@ -1,6 +1,0 @@
-This command uses the following config variables:
-
-- `API_CRYPTO_COMPARE` - **NOT** setup by the setup script.
-  - https://min-api.cryptocompare.com/.
-- `API_FIXER_IO` - **NOT** setup by the setup script.
-  - https://fixer.io/

--- a/commands/cryptogame/update-prices-cron.js
+++ b/commands/cryptogame/update-prices-cron.js
@@ -26,17 +26,17 @@ export default async (cron) => {
 		}).json();
 	});
 
-	const [cryptoData, currencyData, goldData, silverData] = await Promise.allSettled([
+	const [rawCryptoData, currencyData, goldData, silverData] = await Promise.allSettled([
 		core.Got.get("GenericAPI")({
-			url: "https://min-api.cryptocompare.com/data/price",
+			url: "https://api.coingecko.com/api/v3/simple/price",
 			searchParams: {
-				fsym: "EUR",
-				tsyms: "BTC,XRP,DOGE,ETH,BCH,LTC,EOS,XLM,BNB,USDT,DOT,ADA,LINK,XMR,ANAL,SHIB"
+				vs_currencies: "EUR",
+				symbols: "BTC,XRP,DOGE,ETH,BCH,LTC,EOS,XLM,BNB,USDT,DOT,ADA,LINK,XMR,SHIB"
 			},
 			headers: {
-				Authorization: `Apikey ${process.env.API_CRYPTO_COMPARE}`
+				"x-cg-demo-api-key": process.env.API_CRYPTO_GECKO
 			}
-		}).json(),
+		}),
 
 		conditionalFixerIo(),
 
@@ -48,6 +48,11 @@ export default async (cron) => {
 			url: "https://forex-data-feed.swissquote.com/public-quotes/bboquotes/instrument/XAG/EUR"
 		}).json()
 	]);
+
+	const cryptoData = {};
+	for (const [key, value] of Object.entries(rawCryptoData.value.body)) {
+		cryptoData[key.toUpperCase()] = value.eur;
+	}
 
 	const totalData = {
 		...cryptoData?.value,


### PR DESCRIPTION
- formerCryptoCompare (now CoinDesk) imposes an unusable limit of 100+10 API calls monthly (!!)
- switch to a different provider across the `$crypto` and `$cryptogame` commands