### PR TITLE
Overhaul the `languages` module

### DIFF
--- a/classes/command.ts
+++ b/classes/command.ts
@@ -28,7 +28,7 @@ import type { MessageData as TwitchAppendData } from "../platforms/twitch.js";
 import type { MessageData as DiscordAppendData } from "../platforms/discord.js";
 
 import CooldownManager from "../utils/cooldown-manager.js";
-import { type Language, getLanguage } from "../utils/languages.js";
+import { getDefinition as getLanguageDefinition, type LanguageDefinition } from "../utils/languages.js";
 
 import { whitespaceRegex } from "../utils/regexes.js";
 import type { Emote } from "../utils/globals.js";
@@ -47,7 +47,7 @@ type ParameterValueMap = {
 	date: SupiDate;
 	object: Record<string, string>;
 	regex: RegExp;
-	language: Language;
+	language: LanguageDefinition;
 };
 export type ParameterType = keyof ParameterValueMap;
 type ParameterValue = ParameterValueMap[ParameterType];
@@ -1265,7 +1265,7 @@ export class Command extends TemplateWithoutId {
 			}
 
 			case "language": {
-				return getLanguage(value);
+				return getLanguageDefinition(value);
 			}
 		}
 

--- a/commands/define/index.js
+++ b/commands/define/index.js
@@ -9,7 +9,7 @@ export default {
 	Description: "Combines multiple ways of fetching a definition of a word or a phrase, and picks the best result.",
 	Flags: ["mention","non-nullable","pipe"],
 	Params: [
-		{ name: "lang", type: "string" }
+		{ name: "lang", type: "language" }
 	],
 	Whitelist_Response: null,
 	Code: (async function define (context, ...args) {
@@ -25,7 +25,7 @@ export default {
 
 		let languageCode = "en";
 		if (context.params.lang) {
-			languageCode = getCode(context.params.lang, "iso6391");
+			languageCode = context.params.lang.iso6391;
 			if (!languageCode) {
 				return {
 					success: false,

--- a/commands/liveuamap/index.ts
+++ b/commands/liveuamap/index.ts
@@ -23,14 +23,11 @@ export default declare({
 	Params: [{ name: "lang", type: "language" }],
 	Whitelist_Response: null,
 	Code: (async function liveUaMap (context) {
-		const languageCode = (context.params.lang)
-			? context.params.lang.getIsoCode(2)
-			: "en";
-
+		const languageCode = (context.params.lang) ? context.params.lang.iso6392 : "en";
 		if (!languageCode) {
 			return {
 				success: false,
-				reply: `Could not parse your provided language!`
+				reply: `Your provided language could not be parsed!`
 			};
 		}
 		else if (!SUPPORTED_LANGUAGE_CODES.includes(languageCode)) {

--- a/commands/ocr/index.ts
+++ b/commands/ocr/index.ts
@@ -1,6 +1,6 @@
 import * as z from "zod";
 import { SupiError } from "supi-core";
-import { getCode, getName } from "../../utils/languages.js";
+import { getName } from "../../utils/languages.js";
 import { declare } from "../../classes/command.js";
 import RAW_OCR_LANGUAGES from "./ocr-languages.json" with { type: "json" };
 
@@ -37,7 +37,7 @@ export default declare({
 	Params: [
 		{ name: "engine", type: "number" },
 		{ name: "force", type: "boolean" },
-		{ name: "lang", type: "string" }
+		{ name: "lang", type: "language" }
 	],
 	Whitelist_Response: null,
 	Code: async function ocr (context, ...args) {
@@ -49,21 +49,22 @@ export default declare({
 
 		let languageCode: string | null = "eng";
 		if (context.params.lang) {
-			languageCode = getCode(context.params.lang, "iso6393");
-		}
+			const code = context.params.lang.iso6393;
+			if (!code) {
+				return {
+					success: false,
+					reply: "Your provided language could not be parsed!"
+				};
+			}
 
-		if (!languageCode) {
-			return {
-				success: false,
-				reply: "Provided language could not be parsed!"
-			};
+			languageCode = code;
 		}
 
 		const language = ocrLanguages.get(languageCode);
 		if (!language) {
 			return {
 				success: false,
-				reply: `Language is not supported! Use one of these: ${ocrLanguageNames.join(", ")}`,
+				reply: `This language is not supported! Use one of these: ${ocrLanguageNames.join(", ")}`,
 				cooldown: 2500
 			};
 		}

--- a/commands/texttospeech/index.ts
+++ b/commands/texttospeech/index.ts
@@ -79,7 +79,7 @@ export default declare({
 				if (!languageCode) {
 					return {
 						success: false,
-						reply: "Provided language does not exist!"
+						reply: "Your provided language was not recognized!"
 					};
 				}
 

--- a/commands/translate/subcommands/google.ts
+++ b/commands/translate/subcommands/google.ts
@@ -1,5 +1,5 @@
 import { SupiError } from "supi-core";
-import { get as getLanguage, getName } from "../../../utils/languages.js";
+import { hasDefinition, getName, getDefinition } from "../../../utils/languages.js";
 import type { TranslateSubcommandDefinition } from "../index.js";
 
 const LANGUAGE_LIST_KEY = "google-supported-language-list";
@@ -25,7 +25,7 @@ export const getGoogleLanguageList = async () => {
 				return false;
 			}
 
-			return Boolean(getLanguage(i));
+			return hasDefinition(i);
 		}));
 
 		codeList = [...list];
@@ -110,12 +110,12 @@ export default {
 				lang = core.Utils.randArray(codeList);
 			}
 
-			const newLang = getLanguage(lang);
+			const newLang = getDefinition(lang);
 			const code = newLang?.iso6391 ?? newLang?.iso6392 ?? newLang?.iso6393 ?? null;
 			if (!code) {
 				return {
 					success: false,
-					reply: `Language "${lang}" was not recognized!`
+					reply: `Could not recognize language "${lang}"!`
 				};
 			}
 
@@ -124,10 +124,7 @@ export default {
 
 		if (!context.params.to && options.to === "en") {
 			const userDefaultLanguage = await context.user.getDataProperty("defaultUserLanguage");
-
-			options.to = (userDefaultLanguage)
-				? userDefaultLanguage.code.toLowerCase()
-				: "en";
+			options.to = (userDefaultLanguage) ? userDefaultLanguage.code.toLowerCase() : "en";
 		}
 
 		const response = await core.Got.get("FakeAgent")<GoogleTranslateResponse>({

--- a/commands/transliterate/index.ts
+++ b/commands/transliterate/index.ts
@@ -162,7 +162,7 @@ export default declare({
 			};
 		}
 
-		const isoCode = lang.getIsoCode(1);
+		const isoCode = lang.iso6391;
 		if (isoCode === "ja") {
 			return await transliterateJapanese(query);
 		}

--- a/commands/wiki/index.ts
+++ b/commands/wiki/index.ts
@@ -44,7 +44,7 @@ export default declare({
 			};
 		}
 
-		const languageCode = context.params.lang?.getIsoCode(1) ?? "en";
+		const languageCode = context.params.lang?.iso6391 ?? "en";
 		let query = args.join(" ");
 
 		if (query.toLowerCase() === "random") {

--- a/utils/languages-data.json
+++ b/utils/languages-data.json
@@ -329,6 +329,7 @@
       "bhojpuri",
       "भोजपुरी"
     ],
+    "iso6391": null,
     "iso6392": "bho",
     "iso6393": "bho",
     "glottolog": "bhoj1246"
@@ -632,7 +633,6 @@
     "iso6393": "div"
   },
   {
-    "name": "dogri",
     "group": "Indo-Aryan",
     "names": [
       "dogri",
@@ -640,6 +640,7 @@
       "डोगरी",
       "ڈوگری"
     ],
+    "iso6391": null,
     "iso6392": "doi",
     "iso6393": "doi",
     "glottolog": "indo1311"
@@ -871,11 +872,13 @@
     "iso6393": "ger"
   },
   {
-    "name": "goan konkani",
     "group": "Indo-Aryan",
     "names": [
+      "goan konkani",
       "konkani"
     ],
+    "iso6391": null,
+    "iso6392": null,
     "iso6393": "gom",
     "glottolog": "goan1235"
   },
@@ -1091,6 +1094,7 @@
       "samtoy",
       "sao mi ditoy"
     ],
+    "iso6391": null,
     "iso6392": "ilo",
     "iso6393": "ilo",
     "glottolog": "ilok1237"
@@ -1378,6 +1382,7 @@
       "konkani",
       "कोंकणी"
     ],
+    "iso6391": null,
     "iso6392": "kok",
     "iso6393": "kok",
     "glottolog": "konk1267"
@@ -1398,6 +1403,7 @@
       "krio",
       "sierra leona creole"
     ],
+    "iso6391": null,
     "iso6392": null,
     "iso6393": "kri",
     "glottolog": "krio1253"
@@ -1576,6 +1582,7 @@
       "maithili",
       "मैथिली"
     ],
+    "iso6391": null,
     "iso6392": "mai",
     "iso6393": "mai",
     "glottolog": "mait1250"
@@ -1712,7 +1719,6 @@
     "iso6393": "mhr"
   },
   {
-    "name": "",
     "group": "Sino-Tibetan",
     "names": [
       "meitei",
@@ -1725,6 +1731,7 @@
       "kathe",
       "meiteilon (manipuri)"
     ],
+    "iso6391": null,
     "iso6392": "mni",
     "iso6393": "mni",
     "glottolog": "mani1292"
@@ -1747,6 +1754,7 @@
       "duhlian",
       "lushai"
     ],
+    "iso6391": null,
     "iso6392": "lus",
     "iso6393": "lus",
     "glottolog": "lush1249"
@@ -1873,6 +1881,7 @@
       "sesotho sa leboa",
       "sepedi"
     ],
+    "iso6391": null,
     "iso6392": "nso",
     "iso6393": "nso",
     "glottolog": "north3233"
@@ -2320,6 +2329,8 @@
       "central kurdish",
       "kurdish (sorani)"
     ],
+    "iso6391": null,
+    "iso6392": null,
     "iso6393": "ckb"
   },
   {

--- a/utils/languages.ts
+++ b/utils/languages.ts
@@ -1,125 +1,26 @@
+import * as z from "zod";
+// Generated from https://translate.google.com
 import rawLanguages from "./languages-data.json" with { type: "json" };
-export const languages = rawLanguages as LanguageDefinition[];
 
-type NameDescriptor = {
-	native: {
-		short: string;
-		long: string;
-	};
-	english: {
-		short: string;
-		long: string;
-	};
-	transliterations: string[];
-	other: string[];
-};
-type LanguageDefinition = {
-	name: string;
-	group: string;
-	names: string[] | NameDescriptor;
-	iso6391: string;
-	iso6392: string;
-	iso6393: string;
-	glottolog?: string;
-	deprecated?: string;
-};
+const schema = z.array(z.object({
+	group: z.string(),
+	names: z.array(z.string()).min(1),
+	iso6391: z.string().lowercase().nullable(),
+	iso6392: z.string().lowercase().nullable(),
+	iso6393: z.string().lowercase().nullable(),
+	glottolog: z.string().lowercase().optional(),
+	deprecated: z.object({ iso6391: z.string().lowercase() }).optional()
+}));
+
+export type LanguageDefinition = z.infer<typeof schema>[number];
+const languages = schema.parse(rawLanguages);
 
 type IsoCode = "iso6391" | "iso6392" | "iso6393";
-type IsoType = 1 | 2 | 3;
-
-const compileNameList = (lang: NameDescriptor) => [
-	...Object.values(lang.english),
-	...Object.values(lang.native),
-	...lang.transliterations,
-	...lang.other
-];
 
 /**
- * Transformed to ES6 syntax by @supinic
- * Generated from https://translate.google.com *
- * The languages that Google Translate supports (as of 5/15/16) alongside with their ISO 639-1 codes
- * See https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+ * Returns the full definition of a language, or undefined if none was found
  */
-export class Language {
-	#name: string;
-	#glottolog;
-	#isoCodes: [string, string, string];
-	#aliases: string[] = [];
-
-	constructor (data: LanguageDefinition) {
-		this.#name = data.name;
-		this.#isoCodes = [data.iso6391, data.iso6392, data.iso6393];
-
-		if (Array.isArray(data.names)) {
-			this.#aliases.push(...data.names);
-		}
-		else if (typeof data.names === "object") {
-			const { native, english, transliterations, other } = data.names;
-			this.#aliases.push(
-				native.short,
-				native.long,
-				english.short,
-				english.long,
-				...transliterations,
-				...other
-			);
-		}
-
-		if (data.glottolog) {
-			this.#glottolog = data.glottolog;
-		}
-	}
-
-	getIsoCode (type: IsoType): string | undefined {
-		const index = type - 1;
-		return this.#isoCodes[index];
-	}
-
-	get name (): string { return this.#name; }
-	get aliases (): string[] { return this.#aliases; }
-	get glottolog () { return this.#glottolog; }
-}
-
-export const getCode = (string: string, targetCode: IsoCode = "iso6391") => {
-	const target = get(string);
-	if (!target) {
-		return null;
-	}
-	else {
-		return target[targetCode];
-	}
-};
-
-export const getName = (string: string) => {
-	const target = get(string);
-	if (!target) {
-		return null;
-	}
-	else {
-		return (!target.name && Array.isArray(target.names))
-			? target.names[0]
-			: target.name;
-	}
-};
-
-/**
- * Fetches a Language class instance for provided input
- * @param string language-like code, name or ISO code
- */
-export const getLanguage = (string: string) => {
-	const result = get(string);
-	if (!result) {
-		return null;
-	}
-
-	return new Language(result);
-};
-
-/**
- * Returns the full definition of language, or null if none was found
- * @param string name or the code of the desired language
- */
-export const get = (string: string) => {
+export const getDefinition = (string: string): LanguageDefinition | null => {
 	const target = string.toLowerCase();
 	return languages.find(i => (
 		(i.iso6391 === target)
@@ -127,31 +28,20 @@ export const get = (string: string) => {
 		|| (i.iso6393 === target)
 		|| (Array.isArray(i.names) && i.names.includes(target))
 		|| (i.deprecated && Object.values(i.deprecated).includes(target))
-	));
+	)) ?? null;
 };
 
-/**
- * Searches by all names in a language.
- */
-export const search = (string: string) => {
-	const target = string.toLowerCase();
-	const result = languages.find(lang => {
-		const names = (Array.isArray(lang.names))
-			? lang.names
-			: compileNameList(lang.names);
-
-		return names.includes(target);
-	});
-
-	return result ?? null;
+export const hasDefinition = (string: string): boolean => {
+	const definition = getDefinition(string);
+	return Boolean(definition);
 };
 
-export default {
-	Language,
-	languages,
-	search,
-	get,
-	getCode,
-	getLanguage,
-	getName
+export const getCode = (string: string, targetCode: IsoCode = "iso6391") => {
+	const target = getDefinition(string);
+	return (target) ? target[targetCode] : null;
+};
+
+export const getName = (string: string) => {
+	const target = getDefinition(string);
+	return (target) ? target.names[0] : null;
 };


### PR DESCRIPTION
- simplify languages helper
- no more Language class, use definitions
- `$define` replace `string` type with `language`
- replace Language class API with direct properties access