### PR TITLE
docs: fix typo requred -> required

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -72,7 +72,7 @@ This can be different for each platform, hence why this level of abstraction exi
 
 ### Command code API
 The entirety of each command's code consists of a single function. 
-This function will be `await`-ed in `checkAndExecute` regardless of whether it is sync or async, so if asynchronous behaviour is requred, the function should be declared as `async`.
+This function will be `await`-ed in `checkAndExecute` regardless of whether it is sync or async, so if asynchronous behaviour is required, the function should be declared as `async`.
 
 All command functions are await-ed.
 So, if asynchronous operation is required, feel free to make the function `async` and use `await` inside of it.


### PR DESCRIPTION
One-word typo fix in `docs/commands.md:75`: "This function will be \`await\`-ed in \`che...\` requred" → "required".

### Deliberately not changed

Lines 90 and 96 also contain `overriden`, but there it is literal sample *command input* the user types — `\$foo param:foo param:"overriden!"` — not prose. Correcting it would change the example's data rather than fix a mistake.
