### PR TITLE
rss: add SUSE security team blog

### DIFF
--- a/commands/subscribe/event-types/rss-definitions.json
+++ b/commands/subscribe/event-types/rss-definitions.json
@@ -116,6 +116,12 @@
     "url": "https://www.gamerpower.com/rss/steam"
   },
   {
+    "title": "SUSE Security Team Blog",
+    "names": ["suse-security"],
+    "item": "blogpost",
+    "url": "https://security.opensuse.org/feed.xml"
+  },
+  {
     "title": "Twitch Developer Changelog",
     "names": ["twitchdev"],
     "item": "update",


### PR DESCRIPTION
I have not tested this on a local instance
